### PR TITLE
Sql fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "async-trait"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,6 +1387,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_decimal"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5446d1cf2dfe2d6367c8b27f2082bdf011e60e76fa1fcd140047f535156d6e7"
+dependencies = [
+ "arrayvec",
+ "byteorder",
+ "bytes",
+ "num-traits",
+ "postgres",
+ "serde",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,6 +1595,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ron",
+ "rust_decimal",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bigdecimal"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,9 +164,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
@@ -1075,6 +1086,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pg_bigdecimal"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9156af7a012f20d8ed9721f0a7b0c8f2b08b3ca48e5b0771b2fe45994e33213e"
+dependencies = [
+ "bigdecimal",
+ "byteorder",
+ "bytes",
+ "num",
+ "postgres",
+ "serde",
+]
+
+[[package]]
 name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1569,6 +1594,7 @@ dependencies = [
  "log",
  "native-tls",
  "num",
+ "pg_bigdecimal",
  "postgres",
  "postgres-native-tls",
  "pretty_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,12 +57,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "async-trait"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,20 +1381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust_decimal"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5446d1cf2dfe2d6367c8b27f2082bdf011e60e76fa1fcd140047f535156d6e7"
-dependencies = [
- "arrayvec",
- "byteorder",
- "bytes",
- "num-traits",
- "postgres",
- "serde",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,7 +1575,6 @@ dependencies = [
  "regex",
  "reqwest",
  "ron",
- "rust_decimal",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 pretty_assertions = "*"
 
 [dependencies]
+rust_decimal = { version = "1.15", features = ["db-postgres"] }
 backoff = "0.3.0"
 reqwest = { version = "0.11.4", features = ["blocking"] }
 flume = "0.10.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 pretty_assertions = "*"
 
 [dependencies]
-rust_decimal = { version = "1.15", features = ["db-postgres"] }
 backoff = "0.3.0"
 reqwest = { version = "0.11.4", features = ["blocking"] }
 flume = "0.10.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ native-tls = "0.2.7"
 num = { version = "0.4", features = [ "serde" ] }
 postgres = { version = "0.19.1", features = [ "with-chrono-0_4" ] }
 postgres-native-tls = "0.5.0"
+pg_bigdecimal = { version = "0.1.1", features = ["serde"] }
 regex = "1.4.5"
 ron = "0.6.4"
 serde = { version = "1.0.125", features = [ "derive" ] }

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ export DATABASE_URL=host=0.0.0.0 dbname=tezos user=quepasa password=quepasa port
 
 # PMM on GRANADA testnet:
 
-#export NODE_URL=https://testnet-tezos.giganode.io
-#export CONTRACT_ID=KT1B5Jg8unLXy2kvLGDEfvbcca3hQ29d8WhF
-#NETWORK="granadanet"
+export NODE_URL=https://testnet-tezos.giganode.io
+export CONTRACT_ID=KT1B5Jg8unLXy2kvLGDEfvbcca3hQ29d8WhF
+NETWORK="granadanet"
 
 # old PMM contract:
 #export CONTRACT_ID=KT18sHKbZtXhXtnf6ZrHEW9VgEe2eCvRr2CS
@@ -14,9 +14,9 @@ export DATABASE_URL=host=0.0.0.0 dbname=tezos user=quepasa password=quepasa port
 
 # HEN on GRANADA:
 
- export NODE_URL=https://mainnet-tezos.giganode.io
- export CONTRACT_ID=KT1QxLqukyfohPV5kPkw97Rs6cw1DDDvYgbB
- NETWORK="mainnet"
+# export NODE_URL=https://mainnet-tezos.giganode.io
+# export CONTRACT_ID=KT1QxLqukyfohPV5kPkw97Rs6cw1DDDvYgbB
+# NETWORK="mainnet"
 
 
 gen-sql:

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ export DATABASE_URL=host=0.0.0.0 dbname=tezos user=quepasa password=quepasa port
 
 # PMM on GRANADA testnet:
 
-export NODE_URL=https://testnet-tezos.giganode.io
-export CONTRACT_ID=KT1B5Jg8unLXy2kvLGDEfvbcca3hQ29d8WhF
-NETWORK="granadanet"
+#export NODE_URL=https://testnet-tezos.giganode.io
+#export CONTRACT_ID=KT1B5Jg8unLXy2kvLGDEfvbcca3hQ29d8WhF
+#NETWORK="granadanet"
 
 # old PMM contract:
 #export CONTRACT_ID=KT18sHKbZtXhXtnf6ZrHEW9VgEe2eCvRr2CS
@@ -14,9 +14,9 @@ NETWORK="granadanet"
 
 # HEN on GRANADA:
 
-# export NODE_URL=https://mainnet-tezos.giganode.io
-# export CONTRACT_ID=KT1QxLqukyfohPV5kPkw97Rs6cw1DDDvYgbB
-# NETWORK="mainnet"
+ export NODE_URL=https://mainnet-tezos.giganode.io
+ export CONTRACT_ID=KT1QxLqukyfohPV5kPkw97Rs6cw1DDDvYgbB
+ NETWORK="mainnet"
 
 
 gen-sql:

--- a/src/highlevel.rs
+++ b/src/highlevel.rs
@@ -559,7 +559,6 @@ fn test_block() {
                 use std::io::BufReader;
                 let reader = BufReader::new(file);
                 println!("filename: {}", filename);
-                continue;
                 let v: Inserts = ron::de::from_reader(reader).unwrap();
 
                 let mut expected_result: Vec<Insert> =

--- a/src/highlevel.rs
+++ b/src/highlevel.rs
@@ -255,6 +255,7 @@ impl Executor {
                     level._level
                 )
             })?;
+        let tx_count = tx_contexts.len() as u32;
 
         self.save_level_processed_contract(
             level,
@@ -271,7 +272,7 @@ impl Executor {
         Ok(SaveLevelResult {
             level: level._level,
             is_origination: false,
-            tx_count: inserts.len() as u32,
+            tx_count,
         })
     }
 

--- a/src/highlevel.rs
+++ b/src/highlevel.rs
@@ -2,23 +2,15 @@ use crate::octez::block::{Block, LevelMeta};
 use crate::octez::block_getter::ConcurrentBlockGetter;
 use crate::octez::node::NodeClient;
 use crate::relational::RelationalAST;
-use crate::sql::postgresql_generator;
-use crate::sql::postgresql_generator::PostgresqlGenerator;
+use crate::sql::db::DBClient;
+use crate::sql::insert::{InsertKey, Inserts};
 use crate::storage_value::processor::{StorageProcessor, TxContext};
-use crate::table::insert::Inserts;
 use anyhow::{anyhow, Context, Result};
 use std::cmp::Ordering;
 use std::thread;
 
 #[cfg(test)]
 use pretty_assertions::assert_eq;
-
-pub(crate) fn get_origination(
-    _contract_id: &str,
-    dbconn: &mut postgres::Client,
-) -> Result<Option<u32>> {
-    postgresql_generator::get_origination(dbconn)
-}
 
 pub struct SaveLevelResult {
     pub level: u32,
@@ -30,7 +22,7 @@ pub struct Executor {
     node_cli: NodeClient,
     rel_ast: RelationalAST,
     contract_id: String,
-    dbconn: postgres::Client,
+    dbcli: DBClient,
 }
 
 impl Executor {
@@ -38,13 +30,13 @@ impl Executor {
         node_cli: NodeClient,
         rel_ast: RelationalAST,
         contract_id: String,
-        dbconn: postgres::Client,
+        dbcli: DBClient,
     ) -> Self {
         Self {
             node_cli,
             rel_ast,
             contract_id,
-            dbconn,
+            dbcli,
         }
     }
 
@@ -65,7 +57,7 @@ impl Executor {
             }
 
             let chain_head = self.node_cli.head()?;
-            let db_head = match postgresql_generator::get_head(&mut self.dbconn)? {
+            let db_head = match self.dbcli.get_head()? {
                 Some(head) => Ok(head),
                 None => Err(anyhow!(
                     "cannot run in continuous mode: DB is empty, expected at least 1 block present to continue from"
@@ -95,12 +87,9 @@ impl Executor {
                             "Hashes don't match: {:?} (db) <> {:?} (chain)",
                             db_head.hash, chain_head.hash
                         );
-                        let mut transaction = self.dbconn.transaction()?;
-                        postgresql_generator::delete_level(
-                            &mut transaction,
-                            &db_head,
-                        )?;
-                        transaction.commit()?;
+                        let mut tx = self.dbcli.transaction()?;
+                        DBClient::delete_level(&mut tx, &db_head)?;
+                        tx.commit()?;
                     }
                     std::thread::sleep(std::time::Duration::from_millis(1500));
                 }
@@ -122,17 +111,13 @@ impl Executor {
 
     pub fn exec_missing_levels(&mut self, num_getters: usize) -> Result<()> {
         loop {
-            let origination_level =
-                get_origination(&self.contract_id, &mut self.dbconn)?;
+            let origination_level = self.dbcli.get_origination()?;
 
             let latest_level = self.node_cli.head()?._level;
 
-            let missing_levels: Vec<u32> =
-                postgresql_generator::get_missing_levels(
-                    &mut self.dbconn,
-                    origination_level,
-                    latest_level,
-                )?;
+            let missing_levels: Vec<u32> = self
+                .dbcli
+                .get_missing_levels(origination_level, latest_level)?;
             if missing_levels.is_empty() {
                 // finally through them
                 return Ok(());
@@ -174,7 +159,7 @@ impl Executor {
         // fills in all levels in db as empty that are missing between min and max
         // level present
 
-        postgresql_generator::fill_in_levels(&mut self.dbconn)
+        self.dbcli.fill_in_levels()
             .with_context(|| {
                 "failed to mark levels unrelated to the contract as empty in the db"
             })?;
@@ -201,7 +186,9 @@ impl Executor {
     }
 
     fn get_storage_processor(&mut self) -> Result<StorageProcessor> {
-        let id = crate::postgresql_generator::get_max_id(&mut self.dbconn)
+        let id = self
+            .dbcli
+            .get_max_id()
             .with_context(|| {
                 "could not initialize storage processor from the db state"
             })?;
@@ -292,21 +279,19 @@ impl Executor {
         &mut self,
         level: &LevelMeta,
     ) -> Result<()> {
-        let mut transaction =
-            postgresql_generator::transaction(&mut self.dbconn)?;
-        postgresql_generator::delete_level(&mut transaction, level)?;
-        postgresql_generator::save_level(&mut transaction, level)?;
-        postgresql_generator::set_origination(&mut transaction, level._level)?;
-        transaction.commit()?;
+        let mut tx = self.dbcli.transaction()?;
+        DBClient::delete_level(&mut tx, level)?;
+        DBClient::save_level(&mut tx, level)?;
+        DBClient::set_origination(&mut tx, level._level)?;
+        tx.commit()?;
         Ok(())
     }
 
     fn mark_level_empty(&mut self, level: &LevelMeta) -> Result<()> {
-        let mut transaction =
-            postgresql_generator::transaction(&mut self.dbconn)?;
-        postgresql_generator::delete_level(&mut transaction, level)?;
-        postgresql_generator::save_level(&mut transaction, level)?;
-        transaction.commit()?;
+        let mut tx = self.dbcli.transaction()?;
+        DBClient::delete_level(&mut tx, level)?;
+        DBClient::save_level(&mut tx, level)?;
+        tx.commit()?;
         Ok(())
     }
 
@@ -317,29 +302,25 @@ impl Executor {
         tx_contexts: Vec<TxContext>,
         next_id: i32,
     ) -> Result<()> {
-        let mut transaction =
-            postgresql_generator::transaction(&mut self.dbconn)?;
-        postgresql_generator::delete_level(&mut transaction, level)?;
-        postgresql_generator::save_level(&mut transaction, level)?;
+        let mut tx = self.dbcli.transaction()?;
+        DBClient::delete_level(&mut tx, level)?;
+        DBClient::save_level(&mut tx, level)?;
 
-        postgresql_generator::save_tx_contexts(&mut transaction, &tx_contexts)?;
+        DBClient::save_tx_contexts(&mut tx, &tx_contexts)?;
         let mut keys = inserts
             .keys()
-            .collect::<Vec<&crate::table::insert::InsertKey>>();
+            .collect::<Vec<&InsertKey>>();
         keys.sort_by_key(|a| a.id);
-        let generator = PostgresqlGenerator::new();
         for key in keys.iter() {
-            postgresql_generator::exec(
-                &mut transaction,
-                &generator.build_insert(
-                    inserts
-                        .get(key)
-                        .ok_or_else(|| anyhow!("No insert for key"))?,
-                ),
+            DBClient::apply_insert(
+                &mut tx,
+                inserts
+                    .get(key)
+                    .ok_or_else(|| anyhow!("no insert for key"))?,
             )?;
         }
-        postgresql_generator::set_max_id(&mut transaction, next_id)?;
-        transaction.commit()?;
+        DBClient::set_max_id(&mut tx, next_id)?;
+        tx.commit()?;
         Ok(())
     }
 }
@@ -499,10 +480,7 @@ fn test_block() {
         },
     ];
 
-    fn sort_inserts(
-        tables: &TableMap,
-        inserts: &mut Vec<crate::table::insert::Insert>,
-    ) {
+    fn sort_inserts(tables: &TableMap, inserts: &mut Vec<Insert>) {
         inserts.sort_by_key(|insert| {
             let mut res = tables[&insert.table_name]
                 .indices
@@ -521,10 +499,8 @@ fn test_block() {
         });
     }
 
-    let mut results: Vec<(&str, u32, Vec<crate::table::insert::Insert>)> =
-        vec![];
-    let mut expected: Vec<(&str, u32, Vec<crate::table::insert::Insert>)> =
-        vec![];
+    let mut results: Vec<(&str, u32, Vec<Insert>)> = vec![];
+    let mut expected: Vec<(&str, u32, Vec<Insert>)> = vec![];
     for contract in &contracts {
         let mut storage_processor = StorageProcessor::new(1);
 
@@ -572,8 +548,7 @@ fn test_block() {
     "
             );
 
-            let mut result: Vec<crate::table::insert::Insert> =
-                inserts.values().cloned().collect();
+            let mut result: Vec<Insert> = inserts.values().cloned().collect();
             sort_inserts(tables, &mut result);
             results.push((contract.id, *level, result));
 
@@ -585,10 +560,9 @@ fn test_block() {
                 use std::io::BufReader;
                 let reader = BufReader::new(file);
                 println!("filename: {}", filename);
-                let v: crate::table::insert::Inserts =
-                    ron::de::from_reader(reader).unwrap();
+                let v: Inserts = ron::de::from_reader(reader).unwrap();
 
-                let mut expected_result: Vec<crate::table::insert::Insert> =
+                let mut expected_result: Vec<Insert> =
                     v.values().cloned().collect();
                 sort_inserts(tables, &mut expected_result);
 

--- a/src/sql/db.rs
+++ b/src/sql/db.rs
@@ -1,0 +1,337 @@
+use anyhow::{anyhow, Result};
+
+use native_tls::{Certificate, TlsConnector};
+use postgres::{Client, NoTls, Transaction};
+use postgres_native_tls::MakeTlsConnector;
+use std::fs;
+
+use chrono::{DateTime, Utc};
+
+use crate::octez::block::LevelMeta;
+use crate::sql::insert::{Column, Insert, Value};
+use crate::sql::postgresql_generator::PostgresqlGenerator;
+use crate::storage_value::processor::TxContext;
+
+pub struct DBClient {
+    dbconn: postgres::Client,
+}
+
+impl DBClient {
+    pub(crate) fn connect(
+        url: &str,
+        ssl: bool,
+        ca_cert: Option<String>,
+    ) -> Result<Self> {
+        if ssl {
+            let mut builder = TlsConnector::builder();
+            if let Some(ca_cert) = ca_cert {
+                builder.add_root_certificate(Certificate::from_pem(
+                    &fs::read(ca_cert)?,
+                )?);
+            }
+            let connector = builder.build()?;
+            let connector = MakeTlsConnector::new(connector);
+
+            Ok(DBClient {
+                dbconn: postgres::Client::connect(url, connector)?,
+            })
+        } else {
+            Ok(DBClient {
+                dbconn: Client::connect(url, NoTls)?,
+            })
+        }
+    }
+
+    pub(crate) fn save_tx_contexts(
+        transaction: &mut Transaction,
+        tx_context_map: &[TxContext],
+    ) -> Result<()> {
+        let stmt = transaction.prepare("
+INSERT INTO
+tx_contexts(id, level, operation_group_number, operation_number, content_number, internal_number, operation_hash, source, destination, entrypoint) VALUES
+($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)")?;
+        for tx_context in tx_context_map {
+            transaction.execute(
+                &stmt,
+                &[
+                    &(tx_context
+                        .id
+                        .ok_or_else(|| anyhow!("Missing ID on TxContext"))?
+                        as i32),
+                    &(tx_context.level as i32),
+                    &(tx_context.operation_group_number as i32),
+                    &(tx_context.operation_number as i32),
+                    &(tx_context.content_number as i32),
+                    &(tx_context
+                        .internal_number
+                        .map(|n| n as i32)),
+                    &tx_context.operation_hash,
+                    &tx_context.source,
+                    &tx_context.destination,
+                    &tx_context.entrypoint,
+                ],
+            )?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn apply_insert(
+        tx: &mut postgres::Transaction,
+        insert: &Insert,
+    ) -> Result<()> {
+        let mut columns = insert.columns.clone();
+        columns.push(Column {
+            name: "id".to_string(),
+            value: Value::Int(insert.id as i32),
+        });
+        if let Some(fk_id) = insert.fk_id {
+            let parent_name =
+                PostgresqlGenerator::parent_name(&insert.table_name)
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "
+                failed to get parent name from table={}",
+                            insert.table_name
+                        )
+                    })?;
+            columns.push(Column {
+                name: format!("{}_id", parent_name),
+                value: Value::Int(fk_id as i32),
+            });
+        }
+
+        let column_names: String = columns
+            .iter()
+            .map(|x| PostgresqlGenerator::quote_id(&x.name))
+            .collect::<Vec<String>>()
+            .join(", ");
+
+        let value_refs = (1..columns.len() + 1)
+            .map(|i| format!("${}", i.to_string()))
+            .collect::<Vec<String>>()
+            .join(", ");
+
+        let values: Vec<&dyn postgres::types::ToSql> = columns
+            .iter()
+            .map(|x| x.value.borrow_to_sql())
+            .collect();
+
+        let qry = format!(
+            r#"
+INSERT INTO "{}" (
+    {}
+) VALUES (
+    {}
+)"#,
+            insert.table_name, column_names, value_refs,
+        );
+        debug!(
+            "qry: {}, values: {:?}",
+            qry,
+            columns
+                .iter()
+                .cloned()
+                .map(|x| x.value)
+                .collect::<Vec<Value>>()
+        );
+        let stmt = tx.prepare(qry.as_str())?;
+
+        tx.query_raw(&stmt, values)?;
+        Ok(())
+    }
+
+    pub(crate) fn transaction(&mut self) -> Result<Transaction> {
+        Ok(self.dbconn.transaction()?)
+    }
+
+    pub(crate) fn exec(
+        transaction: &mut Transaction,
+        sql: &str,
+    ) -> Result<u64> {
+        match transaction.execute(sql, &[]) {
+            Ok(x) => Ok(x),
+            Err(e) => Err(anyhow!("err on sql={}: {}", sql, e.to_string())),
+        }
+    }
+
+    pub(crate) fn delete_everything(&mut self) -> Result<u64> {
+        Ok(self
+            .dbconn
+            .execute("DELETE FROM levels", &[])?)
+    }
+
+    pub(crate) fn fill_in_levels(&mut self) -> Result<u64> {
+        Ok(self.dbconn.execute(
+            "
+INSERT INTO levels(_level, hash)
+SELECT
+    g.level,
+    NULL
+FROM GENERATE_SERIES(
+    (SELECT MIN(_level) FROM levels),
+    (SELECT MAX(_level) FROM levels)
+) AS g(level)
+WHERE g.level NOT IN (
+    SELECT _level FROM levels
+)",
+            &[],
+        )?)
+    }
+
+    pub(crate) fn get_head(&mut self) -> Result<Option<LevelMeta>> {
+        let result = self.dbconn.query(
+            "
+SELECT _level, hash, is_origination, baked_at
+FROM levels
+ORDER BY _level
+DESC LIMIT 1",
+            &[],
+        )?;
+        if result.is_empty() {
+            Ok(None)
+        } else if result.len() == 1 {
+            let _level: i32 = result[0].get(0);
+            let hash: Option<String> = result[0].get(1);
+            let baked_at: Option<DateTime<Utc>> = result[0].get(3);
+            Ok(Some(LevelMeta {
+                _level: _level as u32,
+                hash,
+                baked_at,
+            }))
+        } else {
+            Err(anyhow!("Too many results for get_head"))
+        }
+    }
+
+    pub(crate) fn get_missing_levels(
+        &mut self,
+        origination: Option<u32>,
+        end: u32,
+    ) -> Result<Vec<u32>> {
+        let start = origination.unwrap_or(1);
+        let mut rows: Vec<i32> = vec![];
+        for row in self.dbconn.query(
+            format!(
+                "
+SELECT
+    *
+FROM generate_series({},{}) s(i)
+WHERE NOT EXISTS (
+    SELECT
+        _level
+    FROM levels
+    WHERE _level = s.i
+)",
+                start, end
+            )
+            .as_str(),
+            &[],
+        )? {
+            rows.push(row.get(0));
+        }
+        rows.reverse();
+        Ok(rows
+            .iter()
+            .map(|x| *x as u32)
+            .collect::<Vec<u32>>())
+    }
+
+    pub(crate) fn get_max_id(&mut self) -> Result<i32> {
+        let max_id: i32 = self
+            .dbconn
+            .query("SELECT max_id FROM max_id", &[])?[0]
+            .get(0);
+        Ok(max_id + 1)
+    }
+
+    pub(crate) fn set_max_id(tx: &mut Transaction, max_id: i32) -> Result<()> {
+        let updated = tx.execute(
+            "
+UPDATE max_id
+SET max_id = $1",
+            &[&max_id],
+        )?;
+        if updated == 1 {
+            Ok(())
+        } else {
+            Err(anyhow!(
+            "Wrong number of rows in max_id table. Please fix manually. Sorry"
+        ))
+        }
+    }
+
+    /// get the origination of the contract, which is currently store in the levels (will change)
+    pub(crate) fn set_origination(
+        transaction: &mut Transaction,
+        level: u32,
+    ) -> Result<()> {
+        Self::exec(
+            transaction,
+            &"
+UPDATE levels
+SET is_origination = FALSE
+WHERE is_origination = TRUE"
+                .to_string(),
+        )?;
+        Self::exec(
+            transaction,
+            &format!(
+                "
+UPDATE levels
+SET is_origination = TRUE
+WHERE _level = {}",
+                level,
+            ),
+        )?;
+        Ok(())
+    }
+
+    pub(crate) fn get_origination(&mut self) -> Result<Option<u32>> {
+        let result = self.dbconn.query(
+            "
+SELECT
+    _level
+FROM levels
+WHERE is_origination = TRUE",
+            &[],
+        )?;
+        if result.is_empty() {
+            Ok(None)
+        } else if result.len() == 1 {
+            let level: i32 = result[0].get(0);
+            Ok(Some(level as u32))
+        } else {
+            Err(anyhow!("Too many results for get_origination"))
+        }
+    }
+
+    pub(crate) fn save_level(
+        tx: &mut Transaction,
+        level: &LevelMeta,
+    ) -> Result<()> {
+        tx.execute(
+            "
+INSERT INTO levels(
+    _level, hash, baked_at
+) VALUES ($1, $2, $3)
+",
+            &[&(level._level as i32), &level.hash, &level.baked_at],
+        )?;
+        Ok(())
+    }
+
+    pub(crate) fn delete_level(
+        transaction: &mut Transaction,
+        level: &LevelMeta,
+    ) -> Result<u64> {
+        Self::exec(
+            transaction,
+            &format!(
+                "
+DELETE FROM levels
+WHERE _level = {}",
+                level._level
+            ),
+        )
+    }
+}

--- a/src/sql/db.rs
+++ b/src/sql/db.rs
@@ -106,65 +106,16 @@ tx_contexts(id, level, operation_group_number, operation_number, content_number,
             .collect::<Vec<String>>()
             .join(", ");
 
-        let v_refs = columns
-            .iter()
-            .enumerate()
-            .map(|(i, c)| {
-                let i = i + 1;
-                match c.value {
-                    Value::Numeric(_) => format!("${}::text", i.to_string()),
-                    Value::Bool(_) => format!("${}::boolean", i.to_string()),
-                    Value::String(_) => format!("${}::text", i.to_string()),
-                    Value::Int(_) => format!("${}::integer", i.to_string()),
-                    Value::BigInt(_) => format!("${}::bigint", i.to_string()),
-                    Value::Timestamp(_) => {
-                        format!("${}::timestamp with time zone", i.to_string())
-                    }
-                    Value::Null => format!("${}", i.to_string()),
-                    //_ => format!("${}", i.to_string()),
-                }
-            })
-            .collect::<Vec<String>>()
-            .join(", ");
-
-        let v_struct = (1..columns.len() + 1)
-            .map(|i| format!("v{}", i.to_string()))
-            .collect::<Vec<String>>()
-            .join(", ");
-
-        let v_select = columns
-            .iter()
-            .enumerate()
-            .map(|(i, c)| {
-                let i = i + 1;
-                match c.value {
-                    Value::Numeric(_) => {
-                        format!("v.v{}::numeric", i.to_string())
-                    }
-                    Value::Bool(_) => format!("v.v{}::boolean", i.to_string()),
-                    Value::String(_) => format!("v.v{}::text", i.to_string()),
-                    Value::Int(_) => format!("v.v{}::integer", i.to_string()),
-                    Value::BigInt(_) => format!("v.v{}::bigint", i.to_string()),
-                    Value::Timestamp(_) => format!(
-                        "v.v{}::timestamp with time zone",
-                        i.to_string()
-                    ),
-                    Value::Null => format!("v.v{}", i.to_string()),
-                }
-            })
+        let v_refs = (1..columns.len() + 1)
+            .map(|i| format!("${}", i.to_string()))
             .collect::<Vec<String>>()
             .join(", ");
 
         let qry = format!(
             r#"
-INSERT INTO "{}" (
-    {}
-)
-SELECT {}
-FROM (
-    VALUES ({})
-) as v({})"#,
-            insert.table_name, v_names, v_select, v_refs, v_struct
+INSERT INTO "{}" ( {} )
+VALUES ( {} )"#,
+            insert.table_name, v_names, v_refs,
         );
         debug!(
             "qry: {}, values: {:?}",

--- a/src/sql/db.rs
+++ b/src/sql/db.rs
@@ -166,7 +166,7 @@ FROM (
 ) as v({})"#,
             insert.table_name, v_names, v_select, v_refs, v_struct
         );
-        println!(
+        debug!(
             "qry: {}, values: {:?}",
             qry,
             columns
@@ -312,8 +312,8 @@ WHERE is_origination = TRUE",
             "
 UPDATE levels
 SET is_origination = TRUE
-WHERE _level = {}",
-            &[&level],
+WHERE _level = $1",
+            &[&(level as i32)],
         )?;
         Ok(())
     }
@@ -360,7 +360,7 @@ INSERT INTO levels(
             "
 DELETE FROM levels
 WHERE _level = $1",
-            &[&level._level],
+            &[&(level._level as i32)],
         )?;
         Ok(())
     }

--- a/src/sql/insert.rs
+++ b/src/sql/insert.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use pg_bigdecimal::PgNumeric;
 use postgres::types::BorrowToSql;
 use std::collections::BTreeMap;
 
@@ -8,7 +9,7 @@ use std::collections::BTreeMap;
 pub enum Value {
     String(String),
     Bool(bool),
-    Numeric(String),
+    Numeric(PgNumeric),
     Int(i32),
     BigInt(i64),
     Timestamp(DateTime<Utc>),
@@ -23,13 +24,13 @@ impl Value {
             Value::Int(i) => i.borrow_to_sql(),
             Value::BigInt(i) => i.borrow_to_sql(),
             Value::Timestamp(t) => t.borrow_to_sql(),
-            Value::Numeric(d) => d.borrow_to_sql(),
+            Value::Numeric(n) => n.borrow_to_sql(),
             Value::Null => "NULL".borrow_to_sql(),
         }
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InsertKey {
     pub table_name: String,
     pub id: u32,

--- a/src/sql/insert.rs
+++ b/src/sql/insert.rs
@@ -1,0 +1,74 @@
+use chrono::{DateTime, Utc};
+use postgres::types::BorrowToSql;
+use rust_decimal::prelude::*;
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum Value {
+    String(String),
+    Bool(bool),
+    Numeric(Decimal),
+    Int(i32),
+    BigInt(i64),
+    Timestamp(DateTime<Utc>),
+    Null,
+}
+
+impl Value {
+    pub(crate) fn borrow_to_sql(&self) -> &dyn postgres::types::ToSql {
+        match self {
+            Value::String(s) => s.borrow_to_sql(),
+            Value::Bool(b) => b.borrow_to_sql(),
+            Value::Int(i) => i.borrow_to_sql(),
+            Value::BigInt(i) => i.borrow_to_sql(),
+            Value::Timestamp(t) => t.borrow_to_sql(),
+            Value::Numeric(d) => d.borrow_to_sql(),
+            Value::Null => "NULL".borrow_to_sql(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Hash, PartialEq, Eq)]
+pub struct InsertKey {
+    pub table_name: String,
+    pub id: u32,
+}
+
+impl std::cmp::Ord for InsertKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        format!("{}{}", other.table_name, other.id)
+            .cmp(&format!("{}{}", self.table_name, self.id))
+    }
+}
+
+impl PartialOrd for InsertKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+//Change name for more clarity?
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Column {
+    pub name: String,
+    pub value: Value,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Insert {
+    pub table_name: String,
+    pub id: u32,
+    pub fk_id: Option<u32>,
+    pub columns: Vec<Column>,
+}
+
+impl Insert {
+    #[cfg(test)]
+    pub fn get_column(&self, name: &str) -> Option<&Column> {
+        self.columns
+            .iter()
+            .find(|column| column.name == name)
+    }
+}
+
+pub type Inserts = BTreeMap<InsertKey, Insert>;

--- a/src/sql/insert.rs
+++ b/src/sql/insert.rs
@@ -1,13 +1,14 @@
 use chrono::{DateTime, Utc};
 use postgres::types::BorrowToSql;
-use rust_decimal::prelude::*;
 use std::collections::BTreeMap;
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize,
+)]
 pub enum Value {
     String(String),
     Bool(bool),
-    Numeric(Decimal),
+    Numeric(String),
     Int(i32),
     BigInt(i64),
     Timestamp(DateTime<Utc>),
@@ -48,13 +49,13 @@ impl PartialOrd for InsertKey {
 }
 
 //Change name for more clarity?
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
 pub struct Column {
     pub name: String,
     pub value: Value,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
 pub struct Insert {
     pub table_name: String,
     pub id: u32,

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -1,3 +1,5 @@
+pub mod db;
+pub mod insert;
 pub mod postgresql_generator;
 pub mod table;
 pub mod table_builder;

--- a/src/sql/postgresql_generator.rs
+++ b/src/sql/postgresql_generator.rs
@@ -204,9 +204,11 @@ CREATE VIEW "{}_live" AS (
         ))
     }
 
+    /*
     fn escape(s: &str) -> String {
         s.to_string()
             .replace("'", "''")
             .replace("\\", "\\\\")
     }
+    */
 }

--- a/src/sql/table.rs
+++ b/src/sql/table.rs
@@ -1,6 +1,5 @@
 use crate::storage_structure::relational::RelationalEntry;
 use crate::storage_structure::typing::{ComplexExprTy, ExprTy, SimpleExprTy};
-use crate::storage_value::parser::Value;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
@@ -81,54 +80,4 @@ impl Table {
             },
         }
     }
-}
-
-pub mod insert {
-    use crate::table::Value;
-    use std::collections::BTreeMap;
-
-    #[derive(Clone, Debug, Serialize, Deserialize, Hash, PartialEq, Eq)]
-    pub struct InsertKey {
-        pub table_name: String,
-        pub id: u32,
-    }
-
-    impl std::cmp::Ord for InsertKey {
-        fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-            format!("{}{}", other.table_name, other.id)
-                .cmp(&format!("{}{}", self.table_name, self.id))
-        }
-    }
-
-    impl PartialOrd for InsertKey {
-        fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-            Some(self.cmp(other))
-        }
-    }
-
-    //Change name for more clarity?
-    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-    pub struct Column {
-        pub name: String,
-        pub value: Value,
-    }
-
-    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-    pub struct Insert {
-        pub table_name: String,
-        pub id: u32,
-        pub fk_id: Option<u32>,
-        pub columns: Vec<Column>,
-    }
-
-    impl Insert {
-        #[cfg(test)]
-        pub fn get_column(&self, name: &str) -> Option<&Column> {
-            self.columns
-                .iter()
-                .find(|column| column.name == name)
-        }
-    }
-
-    pub type Inserts = BTreeMap<InsertKey, Insert>;
 }

--- a/src/storage_structure/typing.rs
+++ b/src/storage_structure/typing.rs
@@ -158,15 +158,15 @@ pub(crate) fn storage_ast_from_json(json: &JsonValue) -> Result<Ele> {
             }
             "list" => {
                 panic!("found a list type, untested. inspect this");
-                let inner_ast =
-                    storage_ast_from_json(&args.unwrap()[0]).unwrap();
-                Ok(Ele {
-                    name: annot,
-                    expr_type: ExprTy::ComplexExprTy(ComplexExprTy::List(
-                        false,
-                        Box::new(inner_ast),
-                    )),
-                })
+                //let inner_ast =
+                //    storage_ast_from_json(&args.unwrap()[0]).unwrap();
+                //Ok(Ele {
+                //    name: annot,
+                //    expr_type: ExprTy::ComplexExprTy(ComplexExprTy::List(
+                //        false,
+                //        Box::new(inner_ast),
+                //    )),
+                //})
             }
             "string" => Ok(simple_expr!(SimpleExprTy::String, annot)),
             "timestamp" => Ok(simple_expr!(SimpleExprTy::Timestamp, annot)),

--- a/src/storage_value/processor.rs
+++ b/src/storage_value/processor.rs
@@ -6,7 +6,6 @@ use crate::storage_structure::typing::{ExprTy, SimpleExprTy};
 use crate::storage_value::parser;
 use anyhow::{anyhow, Context, Result};
 use num::ToPrimitive;
-use rust_decimal::prelude::*;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
@@ -881,9 +880,9 @@ impl StorageProcessor {
                 match v {
                     parser::Value::Int(i)
                     | parser::Value::Mutez(i)
-                    | parser::Value::Nat(i) => Ok(insert::Value::Numeric(
-                        Decimal::from_str(i.to_str_radix(10).as_str()).unwrap(),
-                    )),
+                    | parser::Value::Nat(i) => {
+                        Ok(insert::Value::Numeric(i.to_str_radix(10)))
+                    }
                     _ => Err(anyhow!(
                         "storage2sql_value: failed to match type with value"
                     )),

--- a/src/storage_value/processor.rs
+++ b/src/storage_value/processor.rs
@@ -6,6 +6,7 @@ use crate::storage_structure::typing::{ExprTy, SimpleExprTy};
 use crate::storage_value::parser;
 use anyhow::{anyhow, Context, Result};
 use num::ToPrimitive;
+use pg_bigdecimal::{BigDecimal, PgNumeric};
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
@@ -880,9 +881,9 @@ impl StorageProcessor {
                 match v {
                     parser::Value::Int(i)
                     | parser::Value::Mutez(i)
-                    | parser::Value::Nat(i) => {
-                        Ok(insert::Value::Numeric(i.to_str_radix(10)))
-                    }
+                    | parser::Value::Nat(i) => Ok(insert::Value::Numeric(
+                        PgNumeric::new(Some(BigDecimal::new(i.clone(), 0))),
+                    )),
                     _ => Err(anyhow!(
                         "storage2sql_value: failed to match type with value"
                     )),

--- a/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147806-inserts.json
+++ b/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147806-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "deleted",

--- a/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147807-inserts.json
+++ b/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147807-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    5,
-                ])),
+                value: Int(5),
             ),
             (
                 name: "deleted",

--- a/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147808-inserts.json
+++ b/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147808-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    9,
-                ])),
+                value: Int(9),
             ),
             (
                 name: "deleted",

--- a/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147809-inserts.json
+++ b/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147809-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    13,
-                ])),
+                value: Int(13),
             ),
             (
                 name: "deleted",

--- a/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147810-inserts.json
+++ b/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147810-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    17,
-                ])),
+                value: Int(17),
             ),
             (
                 name: "deleted",

--- a/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147811-inserts.json
+++ b/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147811-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    21,
-                ])),
+                value: Int(21),
             ),
             (
                 name: "deleted",

--- a/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147812-inserts.json
+++ b/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147812-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    25,
-                ])),
+                value: Int(25),
             ),
             (
                 name: "deleted",

--- a/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147813-inserts.json
+++ b/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147813-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    29,
-                ])),
+                value: Int(29),
             ),
             (
                 name: "deleted",

--- a/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147814-inserts.json
+++ b/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147814-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    33,
-                ])),
+                value: Int(33),
             ),
             (
                 name: "deleted",

--- a/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147816-inserts.json
+++ b/test/KT1LYbgNsG2GYMfChaVCXunjECqY59UJRWBf-147816-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    37,
-                ])),
+                value: Int(37),
             ),
             (
                 name: "deleted",

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228459-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228459-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "deleted",
@@ -19,7 +17,7 @@
             ),
             (
                 name: "lambda_repository_creator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -33,9 +31,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_lambda_repository_string_0",

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228460-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228460-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    9,
-                ])),
+                value: Int(9),
             ),
             (
                 name: "deleted",
@@ -19,7 +17,7 @@
             ),
             (
                 name: "lambda_repository_creator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -33,9 +31,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    9,
-                ])),
+                value: Int(9),
             ),
             (
                 name: "idx_lambda_repository_string_0",

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228461-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228461-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    17,
-                ])),
+                value: Int(17),
             ),
             (
                 name: "deleted",
@@ -19,7 +17,7 @@
             ),
             (
                 name: "lambda_repository_creator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -33,9 +31,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    17,
-                ])),
+                value: Int(17),
             ),
             (
                 name: "idx_lambda_repository_string_0",

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228462-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228462-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    25,
-                ])),
+                value: Int(25),
             ),
             (
                 name: "deleted",
@@ -19,7 +17,7 @@
             ),
             (
                 name: "lambda_repository_creator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -33,9 +31,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    25,
-                ])),
+                value: Int(25),
             ),
             (
                 name: "idx_lambda_repository_string_0",

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228463-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228463-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    33,
-                ])),
+                value: Int(33),
             ),
             (
                 name: "deleted",
@@ -19,7 +17,7 @@
             ),
             (
                 name: "lambda_repository_creator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -33,9 +31,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    33,
-                ])),
+                value: Int(33),
             ),
             (
                 name: "idx_lambda_repository_string_0",

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228464-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228464-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    41,
-                ])),
+                value: Int(41),
             ),
             (
                 name: "deleted",
@@ -19,7 +17,7 @@
             ),
             (
                 name: "lambda_repository_creator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -33,9 +31,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    41,
-                ])),
+                value: Int(41),
             ),
             (
                 name: "idx_lambda_repository_string_0",

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228465-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228465-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    49,
-                ])),
+                value: Int(49),
             ),
             (
                 name: "deleted",
@@ -19,7 +17,7 @@
             ),
             (
                 name: "lambda_repository_creator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -33,9 +31,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    49,
-                ])),
+                value: Int(49),
             ),
             (
                 name: "idx_lambda_repository_string_0",

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228466-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228466-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    57,
-                ])),
+                value: Int(57),
             ),
             (
                 name: "deleted",
@@ -19,7 +17,7 @@
             ),
             (
                 name: "lambda_repository_creator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -33,9 +31,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    57,
-                ])),
+                value: Int(57),
             ),
             (
                 name: "idx_lambda_repository_string_0",

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228467-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228467-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    65,
-                ])),
+                value: Int(65),
             ),
             (
                 name: "deleted",
@@ -19,7 +17,7 @@
             ),
             (
                 name: "lambda_repository_creator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -33,9 +31,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    65,
-                ])),
+                value: Int(65),
             ),
             (
                 name: "idx_lambda_repository_string_0",

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228468-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228468-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    73,
-                ])),
+                value: Int(73),
             ),
             (
                 name: "deleted",

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228490-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228490-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    80,
-                ])),
+                value: Int(80),
             ),
             (
                 name: "deleted",
@@ -29,27 +27,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    80,
-                ])),
+                value: Int(80),
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Int((1, [
-                    60019725,
-                ])),
+                value: Numeric("60019725"),
             ),
             (
                 name: "state",
-                value: Unit(Some("storage.market_map.auctionRunning")),
+                value: String("storage.market_map.auctionRunning"),
             ),
             (
                 name: "currency",
-                value: Unit(Some("metadata_fa12")),
+                value: String("metadata_fa12"),
             ),
             (
                 name: "metadata_adjudicator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "metadata_description",
@@ -71,13 +65,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    80,
-                ])),
+                value: Int(80),
             ),
             (
                 name: "metadata_fa12",
-                value: Address("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
+                value: String("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
             ),
         ],
     ),
@@ -91,27 +83,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    80,
-                ])),
+                value: Int(80),
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Int((1, [
-                    50000,
-                ])),
+                value: Numeric("50000"),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Int((1, [
-                    50000,
-                ])),
+                value: Numeric("50000"),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Int((1, [
-                    10000,
-                ])),
+                value: Numeric("10000"),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -129,23 +113,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    80,
-                ])),
+                value: Int(80),
             ),
             (
                 name: "idx_markets_market_id",
-                value: Int((1, [
-                    60019725,
-                ])),
+                value: Numeric("60019725"),
             ),
             (
                 name: "idx_markets_originator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "noname",
-                value: Unit(Some("storage.liquidity_provider_map.bet")),
+                value: String("storage.liquidity_provider_map.bet"),
             ),
         ],
     ),
@@ -159,21 +139,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    80,
-                ])),
+                value: Int(80),
             ),
             (
                 name: "bet_quantity",
-                value: Int((1, [
-                    10000,
-                ])),
+                value: Numeric("10000"),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Int((1, [
-                    5,
-                ])),
+                value: Numeric("5"),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228490-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228490-inserts.json
@@ -31,7 +31,7 @@
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Numeric("60019725"),
+                value: Numeric(Some("60019725")),
             ),
             (
                 name: "state",
@@ -87,15 +87,15 @@
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Numeric("50000"),
+                value: Numeric(Some("50000")),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Numeric("50000"),
+                value: Numeric(Some("50000")),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Numeric("10000"),
+                value: Numeric(Some("10000")),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -117,7 +117,7 @@
             ),
             (
                 name: "idx_markets_market_id",
-                value: Numeric("60019725"),
+                value: Numeric(Some("60019725")),
             ),
             (
                 name: "idx_markets_originator",
@@ -143,11 +143,11 @@
             ),
             (
                 name: "bet_quantity",
-                value: Numeric("10000"),
+                value: Numeric(Some("10000")),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Numeric("5"),
+                value: Numeric(Some("5")),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228505-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228505-inserts.json
@@ -31,7 +31,7 @@
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Numeric("60019725"),
+                value: Numeric(Some("60019725")),
             ),
             (
                 name: "state",
@@ -87,15 +87,15 @@
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Numeric("39000000000050000"),
+                value: Numeric(Some("39000000000050000")),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Numeric("39000000000050000"),
+                value: Numeric(Some("39000000000050000")),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Numeric("500010000"),
+                value: Numeric(Some("500010000")),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -117,7 +117,7 @@
             ),
             (
                 name: "idx_markets_market_id",
-                value: Numeric("60019725"),
+                value: Numeric(Some("60019725")),
             ),
             (
                 name: "idx_markets_originator",
@@ -143,11 +143,11 @@
             ),
             (
                 name: "bet_quantity",
-                value: Numeric("500000000"),
+                value: Numeric(Some("500000000")),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Numeric("78000000"),
+                value: Numeric(Some("78000000")),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228505-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228505-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    92,
-                ])),
+                value: Int(92),
             ),
             (
                 name: "deleted",
@@ -29,27 +27,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    92,
-                ])),
+                value: Int(92),
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Int((1, [
-                    60019725,
-                ])),
+                value: Numeric("60019725"),
             ),
             (
                 name: "state",
-                value: Unit(Some("storage.market_map.auctionRunning")),
+                value: String("storage.market_map.auctionRunning"),
             ),
             (
                 name: "currency",
-                value: Unit(Some("metadata_fa12")),
+                value: String("metadata_fa12"),
             ),
             (
                 name: "metadata_adjudicator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "metadata_description",
@@ -71,13 +65,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    92,
-                ])),
+                value: Int(92),
             ),
             (
                 name: "metadata_fa12",
-                value: Address("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
+                value: String("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
             ),
         ],
     ),
@@ -91,29 +83,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    92,
-                ])),
+                value: Int(92),
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Int((1, [
-                    440288080,
-                    9080395,
-                ])),
+                value: Numeric("39000000000050000"),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Int((1, [
-                    440288080,
-                    9080395,
-                ])),
+                value: Numeric("39000000000050000"),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Int((1, [
-                    500010000,
-                ])),
+                value: Numeric("500010000"),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -131,23 +113,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    92,
-                ])),
+                value: Int(92),
             ),
             (
                 name: "idx_markets_market_id",
-                value: Int((1, [
-                    60019725,
-                ])),
+                value: Numeric("60019725"),
             ),
             (
                 name: "idx_markets_originator",
-                value: Address("tz1azKk3gBJRjW11JAh8J1CBP1tF2NUu5yJ3"),
+                value: String("tz1azKk3gBJRjW11JAh8J1CBP1tF2NUu5yJ3"),
             ),
             (
                 name: "noname",
-                value: Unit(Some("storage.liquidity_provider_map.bet")),
+                value: String("storage.liquidity_provider_map.bet"),
             ),
         ],
     ),
@@ -161,21 +139,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    92,
-                ])),
+                value: Int(92),
             ),
             (
                 name: "bet_quantity",
-                value: Int((1, [
-                    500000000,
-                ])),
+                value: Numeric("500000000"),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Int((1, [
-                    78000000,
-                ])),
+                value: Numeric("78000000"),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228506-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228506-inserts.json
@@ -31,7 +31,7 @@
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Numeric("60019725"),
+                value: Numeric(Some("60019725")),
             ),
             (
                 name: "state",
@@ -87,15 +87,15 @@
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Numeric("78000000000050000"),
+                value: Numeric(Some("78000000000050000")),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Numeric("78000000000050000"),
+                value: Numeric(Some("78000000000050000")),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Numeric("1000010000"),
+                value: Numeric(Some("1000010000")),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -117,7 +117,7 @@
             ),
             (
                 name: "idx_markets_market_id",
-                value: Numeric("60019725"),
+                value: Numeric(Some("60019725")),
             ),
             (
                 name: "idx_markets_originator",
@@ -143,11 +143,11 @@
             ),
             (
                 name: "bet_quantity",
-                value: Numeric("500000000"),
+                value: Numeric(Some("500000000")),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Numeric("78000000"),
+                value: Numeric(Some("78000000")),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228506-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228506-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    104,
-                ])),
+                value: Int(104),
             ),
             (
                 name: "deleted",
@@ -29,27 +27,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    104,
-                ])),
+                value: Int(104),
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Int((1, [
-                    60019725,
-                ])),
+                value: Numeric("60019725"),
             ),
             (
                 name: "state",
-                value: Unit(Some("storage.market_map.auctionRunning")),
+                value: String("storage.market_map.auctionRunning"),
             ),
             (
                 name: "currency",
-                value: Unit(Some("metadata_fa12")),
+                value: String("metadata_fa12"),
             ),
             (
                 name: "metadata_adjudicator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "metadata_description",
@@ -71,13 +65,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    104,
-                ])),
+                value: Int(104),
             ),
             (
                 name: "metadata_fa12",
-                value: Address("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
+                value: String("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
             ),
         ],
     ),
@@ -91,29 +83,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    104,
-                ])),
+                value: Int(104),
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Int((1, [
-                    880526160,
-                    18160790,
-                ])),
+                value: Numeric("78000000000050000"),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Int((1, [
-                    880526160,
-                    18160790,
-                ])),
+                value: Numeric("78000000000050000"),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Int((1, [
-                    1000010000,
-                ])),
+                value: Numeric("1000010000"),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -131,23 +113,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    104,
-                ])),
+                value: Int(104),
             ),
             (
                 name: "idx_markets_market_id",
-                value: Int((1, [
-                    60019725,
-                ])),
+                value: Numeric("60019725"),
             ),
             (
                 name: "idx_markets_originator",
-                value: Address("tz1VA8Y5qDr2yR5kVLhhWd9mkGB1kx7qBrPx"),
+                value: String("tz1VA8Y5qDr2yR5kVLhhWd9mkGB1kx7qBrPx"),
             ),
             (
                 name: "noname",
-                value: Unit(Some("storage.liquidity_provider_map.bet")),
+                value: String("storage.liquidity_provider_map.bet"),
             ),
         ],
     ),
@@ -161,21 +139,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    104,
-                ])),
+                value: Int(104),
             ),
             (
                 name: "bet_quantity",
-                value: Int((1, [
-                    500000000,
-                ])),
+                value: Numeric("500000000"),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Int((1, [
-                    78000000,
-                ])),
+                value: Numeric("78000000"),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228507-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228507-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    116,
-                ])),
+                value: Int(116),
             ),
             (
                 name: "deleted",
@@ -29,27 +27,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    116,
-                ])),
+                value: Int(116),
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Int((1, [
-                    60019725,
-                ])),
+                value: Numeric("60019725"),
             ),
             (
                 name: "state",
-                value: Unit(Some("storage.market_map.auctionRunning")),
+                value: String("storage.market_map.auctionRunning"),
             ),
             (
                 name: "currency",
-                value: Unit(Some("metadata_fa12")),
+                value: String("metadata_fa12"),
             ),
             (
                 name: "metadata_adjudicator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "metadata_description",
@@ -71,13 +65,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    116,
-                ])),
+                value: Int(116),
             ),
             (
                 name: "metadata_fa12",
-                value: Address("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
+                value: String("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
             ),
         ],
     ),
@@ -91,29 +83,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    116,
-                ])),
+                value: Int(116),
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Int((1, [
-                    1320764240,
-                    27241185,
-                ])),
+                value: Numeric("117000000000050000"),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Int((1, [
-                    1320764240,
-                    27241185,
-                ])),
+                value: Numeric("117000000000050000"),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Int((1, [
-                    1500010000,
-                ])),
+                value: Numeric("1500010000"),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -131,23 +113,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    116,
-                ])),
+                value: Int(116),
             ),
             (
                 name: "idx_markets_market_id",
-                value: Int((1, [
-                    60019725,
-                ])),
+                value: Numeric("60019725"),
             ),
             (
                 name: "idx_markets_originator",
-                value: Address("tz1VWU45MQ7nxu5PGgWxgDePemev6bUDNGZ2"),
+                value: String("tz1VWU45MQ7nxu5PGgWxgDePemev6bUDNGZ2"),
             ),
             (
                 name: "noname",
-                value: Unit(Some("storage.liquidity_provider_map.bet")),
+                value: String("storage.liquidity_provider_map.bet"),
             ),
         ],
     ),
@@ -161,21 +139,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    116,
-                ])),
+                value: Int(116),
             ),
             (
                 name: "bet_quantity",
-                value: Int((1, [
-                    500000000,
-                ])),
+                value: Numeric("500000000"),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Int((1, [
-                    78000000,
-                ])),
+                value: Numeric("78000000"),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228507-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228507-inserts.json
@@ -31,7 +31,7 @@
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Numeric("60019725"),
+                value: Numeric(Some("60019725")),
             ),
             (
                 name: "state",
@@ -87,15 +87,15 @@
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Numeric("117000000000050000"),
+                value: Numeric(Some("117000000000050000")),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Numeric("117000000000050000"),
+                value: Numeric(Some("117000000000050000")),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Numeric("1500010000"),
+                value: Numeric(Some("1500010000")),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -117,7 +117,7 @@
             ),
             (
                 name: "idx_markets_market_id",
-                value: Numeric("60019725"),
+                value: Numeric(Some("60019725")),
             ),
             (
                 name: "idx_markets_originator",
@@ -143,11 +143,11 @@
             ),
             (
                 name: "bet_quantity",
-                value: Numeric("500000000"),
+                value: Numeric(Some("500000000")),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Numeric("78000000"),
+                value: Numeric(Some("78000000")),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228508-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228508-inserts.json
@@ -31,7 +31,7 @@
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Numeric("60019725"),
+                value: Numeric(Some("60019725")),
             ),
             (
                 name: "state",
@@ -87,15 +87,15 @@
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Numeric("156000000000050000"),
+                value: Numeric(Some("156000000000050000")),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Numeric("156000000000050000"),
+                value: Numeric(Some("156000000000050000")),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Numeric("2000010000"),
+                value: Numeric(Some("2000010000")),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -117,7 +117,7 @@
             ),
             (
                 name: "idx_markets_market_id",
-                value: Numeric("60019725"),
+                value: Numeric(Some("60019725")),
             ),
             (
                 name: "idx_markets_originator",
@@ -143,11 +143,11 @@
             ),
             (
                 name: "bet_quantity",
-                value: Numeric("500000000"),
+                value: Numeric(Some("500000000")),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Numeric("78000000"),
+                value: Numeric(Some("78000000")),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228508-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228508-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    128,
-                ])),
+                value: Int(128),
             ),
             (
                 name: "deleted",
@@ -29,27 +27,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    128,
-                ])),
+                value: Int(128),
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Int((1, [
-                    60019725,
-                ])),
+                value: Numeric("60019725"),
             ),
             (
                 name: "state",
-                value: Unit(Some("storage.market_map.auctionRunning")),
+                value: String("storage.market_map.auctionRunning"),
             ),
             (
                 name: "currency",
-                value: Unit(Some("metadata_fa12")),
+                value: String("metadata_fa12"),
             ),
             (
                 name: "metadata_adjudicator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "metadata_description",
@@ -71,13 +65,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    128,
-                ])),
+                value: Int(128),
             ),
             (
                 name: "metadata_fa12",
-                value: Address("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
+                value: String("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
             ),
         ],
     ),
@@ -91,29 +83,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    128,
-                ])),
+                value: Int(128),
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Int((1, [
-                    1761002320,
-                    36321580,
-                ])),
+                value: Numeric("156000000000050000"),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Int((1, [
-                    1761002320,
-                    36321580,
-                ])),
+                value: Numeric("156000000000050000"),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Int((1, [
-                    2000010000,
-                ])),
+                value: Numeric("2000010000"),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -131,23 +113,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    128,
-                ])),
+                value: Int(128),
             ),
             (
                 name: "idx_markets_market_id",
-                value: Int((1, [
-                    60019725,
-                ])),
+                value: Numeric("60019725"),
             ),
             (
                 name: "idx_markets_originator",
-                value: Address("tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6"),
+                value: String("tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6"),
             ),
             (
                 name: "noname",
-                value: Unit(Some("storage.liquidity_provider_map.bet")),
+                value: String("storage.liquidity_provider_map.bet"),
             ),
         ],
     ),
@@ -161,21 +139,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    128,
-                ])),
+                value: Int(128),
             ),
             (
                 name: "bet_quantity",
-                value: Int((1, [
-                    500000000,
-                ])),
+                value: Numeric("500000000"),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Int((1, [
-                    78000000,
-                ])),
+                value: Numeric("78000000"),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228509-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228509-inserts.json
@@ -31,7 +31,7 @@
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Numeric("60019725"),
+                value: Numeric(Some("60019725")),
             ),
             (
                 name: "state",
@@ -87,15 +87,15 @@
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Numeric("194999999984400000"),
+                value: Numeric(Some("194999999984400000")),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Numeric("195000000000050000"),
+                value: Numeric(Some("195000000000050000")),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Numeric("2500010000"),
+                value: Numeric(Some("2500010000")),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -117,7 +117,7 @@
             ),
             (
                 name: "idx_markets_market_id",
-                value: Numeric("60019725"),
+                value: Numeric(Some("60019725")),
             ),
             (
                 name: "idx_markets_originator",
@@ -143,11 +143,11 @@
             ),
             (
                 name: "bet_quantity",
-                value: Numeric("500010000"),
+                value: Numeric(Some("500010000")),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Numeric("77998440"),
+                value: Numeric(Some("77998440")),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228509-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228509-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    140,
-                ])),
+                value: Int(140),
             ),
             (
                 name: "deleted",
@@ -29,27 +27,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    140,
-                ])),
+                value: Int(140),
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Int((1, [
-                    60019725,
-                ])),
+                value: Numeric("60019725"),
             ),
             (
                 name: "state",
-                value: Unit(Some("storage.market_map.auctionRunning")),
+                value: String("storage.market_map.auctionRunning"),
             ),
             (
                 name: "currency",
-                value: Unit(Some("metadata_fa12")),
+                value: String("metadata_fa12"),
             ),
             (
                 name: "metadata_adjudicator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "metadata_description",
@@ -71,13 +65,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    140,
-                ])),
+                value: Int(140),
             ),
             (
                 name: "metadata_fa12",
-                value: Address("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
+                value: String("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
             ),
         ],
     ),
@@ -91,29 +83,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    140,
-                ])),
+                value: Int(140),
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Int((1, [
-                    2185590400,
-                    45401975,
-                ])),
+                value: Numeric("194999999984400000"),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Int((1, [
-                    2201240400,
-                    45401975,
-                ])),
+                value: Numeric("195000000000050000"),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Int((1, [
-                    2500010000,
-                ])),
+                value: Numeric("2500010000"),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -131,23 +113,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    140,
-                ])),
+                value: Int(140),
             ),
             (
                 name: "idx_markets_market_id",
-                value: Int((1, [
-                    60019725,
-                ])),
+                value: Numeric("60019725"),
             ),
             (
                 name: "idx_markets_originator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "noname",
-                value: Unit(Some("storage.liquidity_provider_map.bet")),
+                value: String("storage.liquidity_provider_map.bet"),
             ),
         ],
     ),
@@ -161,21 +139,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    140,
-                ])),
+                value: Int(140),
             ),
             (
                 name: "bet_quantity",
-                value: Int((1, [
-                    500010000,
-                ])),
+                value: Numeric("500010000"),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Int((1, [
-                    77998440,
-                ])),
+                value: Numeric("77998440"),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228510-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228510-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    152,
-                ])),
+                value: Int(152),
             ),
             (
                 name: "deleted",
@@ -29,27 +27,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    152,
-                ])),
+                value: Int(152),
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Int((1, [
-                    60019725,
-                ])),
+                value: Numeric("60019725"),
             ),
             (
                 name: "state",
-                value: Unit(Some("storage.market_map.auctionRunning")),
+                value: String("storage.market_map.auctionRunning"),
             ),
             (
                 name: "currency",
-                value: Unit(Some("metadata_fa12")),
+                value: String("metadata_fa12"),
             ),
             (
                 name: "metadata_adjudicator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "metadata_description",
@@ -71,13 +65,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    152,
-                ])),
+                value: Int(152),
             ),
             (
                 name: "metadata_fa12",
-                value: Address("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
+                value: String("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
             ),
         ],
     ),
@@ -91,29 +83,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    152,
-                ])),
+                value: Int(152),
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Int((1, [
-                    2625828480,
-                    54482370,
-                ])),
+                value: Numeric("233999999984400000"),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Int((1, [
-                    2641478480,
-                    54482370,
-                ])),
+                value: Numeric("234000000000050000"),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Int((1, [
-                    3000010000,
-                ])),
+                value: Numeric("3000010000"),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -131,23 +113,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    152,
-                ])),
+                value: Int(152),
             ),
             (
                 name: "idx_markets_market_id",
-                value: Int((1, [
-                    60019725,
-                ])),
+                value: Numeric("60019725"),
             ),
             (
                 name: "idx_markets_originator",
-                value: Address("tz1LQn3AuoxRVwBsb3rVLQ56nRvC3JqNgVxR"),
+                value: String("tz1LQn3AuoxRVwBsb3rVLQ56nRvC3JqNgVxR"),
             ),
             (
                 name: "noname",
-                value: Unit(Some("storage.liquidity_provider_map.bet")),
+                value: String("storage.liquidity_provider_map.bet"),
             ),
         ],
     ),
@@ -161,21 +139,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    152,
-                ])),
+                value: Int(152),
             ),
             (
                 name: "bet_quantity",
-                value: Int((1, [
-                    500000000,
-                ])),
+                value: Numeric("500000000"),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Int((1, [
-                    78000000,
-                ])),
+                value: Numeric("78000000"),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228510-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228510-inserts.json
@@ -31,7 +31,7 @@
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Numeric("60019725"),
+                value: Numeric(Some("60019725")),
             ),
             (
                 name: "state",
@@ -87,15 +87,15 @@
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Numeric("233999999984400000"),
+                value: Numeric(Some("233999999984400000")),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Numeric("234000000000050000"),
+                value: Numeric(Some("234000000000050000")),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Numeric("3000010000"),
+                value: Numeric(Some("3000010000")),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -117,7 +117,7 @@
             ),
             (
                 name: "idx_markets_market_id",
-                value: Numeric("60019725"),
+                value: Numeric(Some("60019725")),
             ),
             (
                 name: "idx_markets_originator",
@@ -143,11 +143,11 @@
             ),
             (
                 name: "bet_quantity",
-                value: Numeric("500000000"),
+                value: Numeric(Some("500000000")),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Numeric("78000000"),
+                value: Numeric(Some("78000000")),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228511-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228511-inserts.json
@@ -31,7 +31,7 @@
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Numeric("60019725"),
+                value: Numeric(Some("60019725")),
             ),
             (
                 name: "state",
@@ -87,15 +87,15 @@
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Numeric("272999999984400000"),
+                value: Numeric(Some("272999999984400000")),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Numeric("273000000000050000"),
+                value: Numeric(Some("273000000000050000")),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Numeric("3500010000"),
+                value: Numeric(Some("3500010000")),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -117,7 +117,7 @@
             ),
             (
                 name: "idx_markets_market_id",
-                value: Numeric("60019725"),
+                value: Numeric(Some("60019725")),
             ),
             (
                 name: "idx_markets_originator",
@@ -143,11 +143,11 @@
             ),
             (
                 name: "bet_quantity",
-                value: Numeric("500000000"),
+                value: Numeric(Some("500000000")),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Numeric("78000000"),
+                value: Numeric(Some("78000000")),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228511-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228511-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    164,
-                ])),
+                value: Int(164),
             ),
             (
                 name: "deleted",
@@ -29,27 +27,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    164,
-                ])),
+                value: Int(164),
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Int((1, [
-                    60019725,
-                ])),
+                value: Numeric("60019725"),
             ),
             (
                 name: "state",
-                value: Unit(Some("storage.market_map.auctionRunning")),
+                value: String("storage.market_map.auctionRunning"),
             ),
             (
                 name: "currency",
-                value: Unit(Some("metadata_fa12")),
+                value: String("metadata_fa12"),
             ),
             (
                 name: "metadata_adjudicator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "metadata_description",
@@ -71,13 +65,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    164,
-                ])),
+                value: Int(164),
             ),
             (
                 name: "metadata_fa12",
-                value: Address("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
+                value: String("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
             ),
         ],
     ),
@@ -91,29 +83,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    164,
-                ])),
+                value: Int(164),
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Int((1, [
-                    3066066560,
-                    63562765,
-                ])),
+                value: Numeric("272999999984400000"),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Int((1, [
-                    3081716560,
-                    63562765,
-                ])),
+                value: Numeric("273000000000050000"),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Int((1, [
-                    3500010000,
-                ])),
+                value: Numeric("3500010000"),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -131,23 +113,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    164,
-                ])),
+                value: Int(164),
             ),
             (
                 name: "idx_markets_market_id",
-                value: Int((1, [
-                    60019725,
-                ])),
+                value: Numeric("60019725"),
             ),
             (
                 name: "idx_markets_originator",
-                value: Address("tz1Q3eT3kwr1hfvK49HK8YqPadNXzxdxnE7u"),
+                value: String("tz1Q3eT3kwr1hfvK49HK8YqPadNXzxdxnE7u"),
             ),
             (
                 name: "noname",
-                value: Unit(Some("storage.liquidity_provider_map.bet")),
+                value: String("storage.liquidity_provider_map.bet"),
             ),
         ],
     ),
@@ -161,21 +139,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    164,
-                ])),
+                value: Int(164),
             ),
             (
                 name: "bet_quantity",
-                value: Int((1, [
-                    500000000,
-                ])),
+                value: Numeric("500000000"),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Int((1, [
-                    78000000,
-                ])),
+                value: Numeric("78000000"),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228512-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228512-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    176,
-                ])),
+                value: Int(176),
             ),
             (
                 name: "deleted",
@@ -29,27 +27,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    176,
-                ])),
+                value: Int(176),
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Int((1, [
-                    60019725,
-                ])),
+                value: Numeric("60019725"),
             ),
             (
                 name: "state",
-                value: Unit(Some("storage.market_map.auctionRunning")),
+                value: String("storage.market_map.auctionRunning"),
             ),
             (
                 name: "currency",
-                value: Unit(Some("metadata_fa12")),
+                value: String("metadata_fa12"),
             ),
             (
                 name: "metadata_adjudicator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "metadata_description",
@@ -71,13 +65,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    176,
-                ])),
+                value: Int(176),
             ),
             (
                 name: "metadata_fa12",
-                value: Address("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
+                value: String("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
             ),
         ],
     ),
@@ -91,29 +83,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    176,
-                ])),
+                value: Int(176),
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Int((1, [
-                    3506304640,
-                    72643160,
-                ])),
+                value: Numeric("311999999984400000"),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Int((1, [
-                    3521954640,
-                    72643160,
-                ])),
+                value: Numeric("312000000000050000"),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Int((1, [
-                    4000010000,
-                ])),
+                value: Numeric("4000010000"),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -131,23 +113,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    176,
-                ])),
+                value: Int(176),
             ),
             (
                 name: "idx_markets_market_id",
-                value: Int((1, [
-                    60019725,
-                ])),
+                value: Numeric("60019725"),
             ),
             (
                 name: "idx_markets_originator",
-                value: Address("tz1aHRZdotP9mVuPmzUcMAGmcTghTHfJLkZM"),
+                value: String("tz1aHRZdotP9mVuPmzUcMAGmcTghTHfJLkZM"),
             ),
             (
                 name: "noname",
-                value: Unit(Some("storage.liquidity_provider_map.bet")),
+                value: String("storage.liquidity_provider_map.bet"),
             ),
         ],
     ),
@@ -161,21 +139,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    176,
-                ])),
+                value: Int(176),
             ),
             (
                 name: "bet_quantity",
-                value: Int((1, [
-                    500000000,
-                ])),
+                value: Numeric("500000000"),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Int((1, [
-                    78000000,
-                ])),
+                value: Numeric("78000000"),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228512-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228512-inserts.json
@@ -31,7 +31,7 @@
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Numeric("60019725"),
+                value: Numeric(Some("60019725")),
             ),
             (
                 name: "state",
@@ -87,15 +87,15 @@
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Numeric("311999999984400000"),
+                value: Numeric(Some("311999999984400000")),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Numeric("312000000000050000"),
+                value: Numeric(Some("312000000000050000")),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Numeric("4000010000"),
+                value: Numeric(Some("4000010000")),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -117,7 +117,7 @@
             ),
             (
                 name: "idx_markets_market_id",
-                value: Numeric("60019725"),
+                value: Numeric(Some("60019725")),
             ),
             (
                 name: "idx_markets_originator",
@@ -143,11 +143,11 @@
             ),
             (
                 name: "bet_quantity",
-                value: Numeric("500000000"),
+                value: Numeric(Some("500000000")),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Numeric("78000000"),
+                value: Numeric(Some("78000000")),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228516-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228516-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    188,
-                ])),
+                value: Int(188),
             ),
             (
                 name: "deleted",
@@ -29,27 +27,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    188,
-                ])),
+                value: Int(188),
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Int((1, [
-                    82195281,
-                ])),
+                value: Numeric("82195281"),
             ),
             (
                 name: "state",
-                value: Unit(Some("storage.market_map.auctionRunning")),
+                value: String("storage.market_map.auctionRunning"),
             ),
             (
                 name: "currency",
-                value: Unit(Some("metadata_fa12")),
+                value: String("metadata_fa12"),
             ),
             (
                 name: "metadata_adjudicator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "metadata_description",
@@ -71,13 +65,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    188,
-                ])),
+                value: Int(188),
             ),
             (
                 name: "metadata_fa12",
-                value: Address("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
+                value: String("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
             ),
         ],
     ),
@@ -91,27 +83,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    188,
-                ])),
+                value: Int(188),
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Int((1, [
-                    2500000,
-                ])),
+                value: Numeric("2500000"),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Int((1, [
-                    2500000,
-                ])),
+                value: Numeric("2500000"),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Int((1, [
-                    100000,
-                ])),
+                value: Numeric("100000"),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -129,23 +113,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    188,
-                ])),
+                value: Int(188),
             ),
             (
                 name: "idx_markets_market_id",
-                value: Int((1, [
-                    82195281,
-                ])),
+                value: Numeric("82195281"),
             ),
             (
                 name: "idx_markets_originator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "noname",
-                value: Unit(Some("storage.liquidity_provider_map.bet")),
+                value: String("storage.liquidity_provider_map.bet"),
             ),
         ],
     ),
@@ -159,21 +139,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    188,
-                ])),
+                value: Int(188),
             ),
             (
                 name: "bet_quantity",
-                value: Int((1, [
-                    100000,
-                ])),
+                value: Numeric("100000"),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Int((1, [
-                    25,
-                ])),
+                value: Numeric("25"),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228516-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228516-inserts.json
@@ -31,7 +31,7 @@
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Numeric("82195281"),
+                value: Numeric(Some("82195281")),
             ),
             (
                 name: "state",
@@ -87,15 +87,15 @@
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Numeric("2500000"),
+                value: Numeric(Some("2500000")),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Numeric("2500000"),
+                value: Numeric(Some("2500000")),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Numeric("100000"),
+                value: Numeric(Some("100000")),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -117,7 +117,7 @@
             ),
             (
                 name: "idx_markets_market_id",
-                value: Numeric("82195281"),
+                value: Numeric(Some("82195281")),
             ),
             (
                 name: "idx_markets_originator",
@@ -143,11 +143,11 @@
             ),
             (
                 name: "bet_quantity",
-                value: Numeric("100000"),
+                value: Numeric(Some("100000")),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Numeric("25"),
+                value: Numeric(Some("25")),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228521-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228521-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    201,
-                ])),
+                value: Int(201),
             ),
             (
                 name: "deleted",
@@ -29,9 +27,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    200,
-                ])),
+                value: Int(200),
             ),
             (
                 name: "deleted",
@@ -49,27 +45,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    201,
-                ])),
+                value: Int(201),
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Int((1, [
-                    82195281,
-                ])),
+                value: Numeric("82195281"),
             ),
             (
                 name: "state",
-                value: Unit(Some("storage.market_map.auctionRunning")),
+                value: String("storage.market_map.auctionRunning"),
             ),
             (
                 name: "currency",
-                value: Unit(Some("metadata_fa12")),
+                value: String("metadata_fa12"),
             ),
             (
                 name: "metadata_adjudicator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "metadata_description",
@@ -91,27 +83,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    200,
-                ])),
+                value: Int(200),
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Int((1, [
-                    82195281,
-                ])),
+                value: Numeric("82195281"),
             ),
             (
                 name: "state",
-                value: Unit(Some("storage.market_map.auctionRunning")),
+                value: String("storage.market_map.auctionRunning"),
             ),
             (
                 name: "currency",
-                value: Unit(Some("metadata_fa12")),
+                value: String("metadata_fa12"),
             ),
             (
                 name: "metadata_adjudicator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "metadata_description",
@@ -133,13 +121,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    201,
-                ])),
+                value: Int(201),
             ),
             (
                 name: "metadata_fa12",
-                value: Address("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
+                value: String("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
             ),
         ],
     ),
@@ -153,13 +139,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    200,
-                ])),
+                value: Int(200),
             ),
             (
                 name: "metadata_fa12",
-                value: Address("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
+                value: String("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
             ),
         ],
     ),
@@ -173,29 +157,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    201,
-                ])),
+                value: Int(201),
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Int((1, [
-                    1973233056,
-                    8847564,
-                ])),
+                value: Numeric("38000000002500000"),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Int((1, [
-                    1973233056,
-                    8847564,
-                ])),
+                value: Numeric("38000000002500000"),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Int((1, [
-                    1000100000,
-                ])),
+                value: Numeric("1000100000"),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -213,29 +187,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    200,
-                ])),
+                value: Int(200),
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Int((1, [
-                    987866528,
-                    4423782,
-                ])),
+                value: Numeric("19000000002500000"),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Int((1, [
-                    987866528,
-                    4423782,
-                ])),
+                value: Numeric("19000000002500000"),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Int((1, [
-                    500100000,
-                ])),
+                value: Numeric("500100000"),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -253,23 +217,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    201,
-                ])),
+                value: Int(201),
             ),
             (
                 name: "idx_markets_market_id",
-                value: Int((1, [
-                    82195281,
-                ])),
+                value: Numeric("82195281"),
             ),
             (
                 name: "idx_markets_originator",
-                value: Address("tz1azKk3gBJRjW11JAh8J1CBP1tF2NUu5yJ3"),
+                value: String("tz1azKk3gBJRjW11JAh8J1CBP1tF2NUu5yJ3"),
             ),
             (
                 name: "noname",
-                value: Unit(Some("storage.liquidity_provider_map.bet")),
+                value: String("storage.liquidity_provider_map.bet"),
             ),
         ],
     ),
@@ -283,23 +243,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    200,
-                ])),
+                value: Int(200),
             ),
             (
                 name: "idx_markets_market_id",
-                value: Int((1, [
-                    82195281,
-                ])),
+                value: Numeric("82195281"),
             ),
             (
                 name: "idx_markets_originator",
-                value: Address("tz1VA8Y5qDr2yR5kVLhhWd9mkGB1kx7qBrPx"),
+                value: String("tz1VA8Y5qDr2yR5kVLhhWd9mkGB1kx7qBrPx"),
             ),
             (
                 name: "noname",
-                value: Unit(Some("storage.liquidity_provider_map.bet")),
+                value: String("storage.liquidity_provider_map.bet"),
             ),
         ],
     ),
@@ -313,21 +269,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    201,
-                ])),
+                value: Int(201),
             ),
             (
                 name: "bet_quantity",
-                value: Int((1, [
-                    500000000,
-                ])),
+                value: Numeric("500000000"),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Int((1, [
-                    38000000,
-                ])),
+                value: Numeric("38000000"),
             ),
         ],
     ),
@@ -341,21 +291,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    200,
-                ])),
+                value: Int(200),
             ),
             (
                 name: "bet_quantity",
-                value: Int((1, [
-                    500000000,
-                ])),
+                value: Numeric("500000000"),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Int((1, [
-                    38000000,
-                ])),
+                value: Numeric("38000000"),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228521-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228521-inserts.json
@@ -49,7 +49,7 @@
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Numeric("82195281"),
+                value: Numeric(Some("82195281")),
             ),
             (
                 name: "state",
@@ -87,7 +87,7 @@
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Numeric("82195281"),
+                value: Numeric(Some("82195281")),
             ),
             (
                 name: "state",
@@ -161,15 +161,15 @@
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Numeric("38000000002500000"),
+                value: Numeric(Some("38000000002500000")),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Numeric("38000000002500000"),
+                value: Numeric(Some("38000000002500000")),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Numeric("1000100000"),
+                value: Numeric(Some("1000100000")),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -191,15 +191,15 @@
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Numeric("19000000002500000"),
+                value: Numeric(Some("19000000002500000")),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Numeric("19000000002500000"),
+                value: Numeric(Some("19000000002500000")),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Numeric("500100000"),
+                value: Numeric(Some("500100000")),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -221,7 +221,7 @@
             ),
             (
                 name: "idx_markets_market_id",
-                value: Numeric("82195281"),
+                value: Numeric(Some("82195281")),
             ),
             (
                 name: "idx_markets_originator",
@@ -247,7 +247,7 @@
             ),
             (
                 name: "idx_markets_market_id",
-                value: Numeric("82195281"),
+                value: Numeric(Some("82195281")),
             ),
             (
                 name: "idx_markets_originator",
@@ -273,11 +273,11 @@
             ),
             (
                 name: "bet_quantity",
-                value: Numeric("500000000"),
+                value: Numeric(Some("500000000")),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Numeric("38000000"),
+                value: Numeric(Some("38000000")),
             ),
         ],
     ),
@@ -295,11 +295,11 @@
             ),
             (
                 name: "bet_quantity",
-                value: Numeric("500000000"),
+                value: Numeric(Some("500000000")),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Numeric("38000000"),
+                value: Numeric(Some("38000000")),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228522-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228522-inserts.json
@@ -31,7 +31,7 @@
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Numeric("82195281"),
+                value: Numeric(Some("82195281")),
             ),
             (
                 name: "state",
@@ -87,15 +87,15 @@
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Numeric("57000000002500000"),
+                value: Numeric(Some("57000000002500000")),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Numeric("57000000002500000"),
+                value: Numeric(Some("57000000002500000")),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Numeric("1500100000"),
+                value: Numeric(Some("1500100000")),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -117,7 +117,7 @@
             ),
             (
                 name: "idx_markets_market_id",
-                value: Numeric("82195281"),
+                value: Numeric(Some("82195281")),
             ),
             (
                 name: "idx_markets_originator",
@@ -143,11 +143,11 @@
             ),
             (
                 name: "bet_quantity",
-                value: Numeric("500000000"),
+                value: Numeric(Some("500000000")),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Numeric("38000000"),
+                value: Numeric(Some("38000000")),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228522-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228522-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    224,
-                ])),
+                value: Int(224),
             ),
             (
                 name: "deleted",
@@ -29,27 +27,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    224,
-                ])),
+                value: Int(224),
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Int((1, [
-                    82195281,
-                ])),
+                value: Numeric("82195281"),
             ),
             (
                 name: "state",
-                value: Unit(Some("storage.market_map.auctionRunning")),
+                value: String("storage.market_map.auctionRunning"),
             ),
             (
                 name: "currency",
-                value: Unit(Some("metadata_fa12")),
+                value: String("metadata_fa12"),
             ),
             (
                 name: "metadata_adjudicator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "metadata_description",
@@ -71,13 +65,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    224,
-                ])),
+                value: Int(224),
             ),
             (
                 name: "metadata_fa12",
-                value: Address("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
+                value: String("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
             ),
         ],
     ),
@@ -91,29 +83,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    224,
-                ])),
+                value: Int(224),
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Int((1, [
-                    2958599584,
-                    13271346,
-                ])),
+                value: Numeric("57000000002500000"),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Int((1, [
-                    2958599584,
-                    13271346,
-                ])),
+                value: Numeric("57000000002500000"),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Int((1, [
-                    1500100000,
-                ])),
+                value: Numeric("1500100000"),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -131,23 +113,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    224,
-                ])),
+                value: Int(224),
             ),
             (
                 name: "idx_markets_market_id",
-                value: Int((1, [
-                    82195281,
-                ])),
+                value: Numeric("82195281"),
             ),
             (
                 name: "idx_markets_originator",
-                value: Address("tz1VWU45MQ7nxu5PGgWxgDePemev6bUDNGZ2"),
+                value: String("tz1VWU45MQ7nxu5PGgWxgDePemev6bUDNGZ2"),
             ),
             (
                 name: "noname",
-                value: Unit(Some("storage.liquidity_provider_map.bet")),
+                value: String("storage.liquidity_provider_map.bet"),
             ),
         ],
     ),
@@ -161,21 +139,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    224,
-                ])),
+                value: Int(224),
             ),
             (
                 name: "bet_quantity",
-                value: Int((1, [
-                    500000000,
-                ])),
+                value: Numeric("500000000"),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Int((1, [
-                    38000000,
-                ])),
+                value: Numeric("38000000"),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228523-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228523-inserts.json
@@ -31,7 +31,7 @@
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Numeric("82195281"),
+                value: Numeric(Some("82195281")),
             ),
             (
                 name: "state",
@@ -87,15 +87,15 @@
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Numeric("76000000002500000"),
+                value: Numeric(Some("76000000002500000")),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Numeric("76000000002500000"),
+                value: Numeric(Some("76000000002500000")),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Numeric("2000100000"),
+                value: Numeric(Some("2000100000")),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -117,7 +117,7 @@
             ),
             (
                 name: "idx_markets_market_id",
-                value: Numeric("82195281"),
+                value: Numeric(Some("82195281")),
             ),
             (
                 name: "idx_markets_originator",
@@ -143,11 +143,11 @@
             ),
             (
                 name: "bet_quantity",
-                value: Numeric("500000000"),
+                value: Numeric(Some("500000000")),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Numeric("38000000"),
+                value: Numeric(Some("38000000")),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228523-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228523-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    236,
-                ])),
+                value: Int(236),
             ),
             (
                 name: "deleted",
@@ -29,27 +27,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    236,
-                ])),
+                value: Int(236),
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Int((1, [
-                    82195281,
-                ])),
+                value: Numeric("82195281"),
             ),
             (
                 name: "state",
-                value: Unit(Some("storage.market_map.auctionRunning")),
+                value: String("storage.market_map.auctionRunning"),
             ),
             (
                 name: "currency",
-                value: Unit(Some("metadata_fa12")),
+                value: String("metadata_fa12"),
             ),
             (
                 name: "metadata_adjudicator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "metadata_description",
@@ -71,13 +65,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    236,
-                ])),
+                value: Int(236),
             ),
             (
                 name: "metadata_fa12",
-                value: Address("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
+                value: String("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
             ),
         ],
     ),
@@ -91,29 +83,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    236,
-                ])),
+                value: Int(236),
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Int((1, [
-                    3943966112,
-                    17695128,
-                ])),
+                value: Numeric("76000000002500000"),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Int((1, [
-                    3943966112,
-                    17695128,
-                ])),
+                value: Numeric("76000000002500000"),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Int((1, [
-                    2000100000,
-                ])),
+                value: Numeric("2000100000"),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -131,23 +113,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    236,
-                ])),
+                value: Int(236),
             ),
             (
                 name: "idx_markets_market_id",
-                value: Int((1, [
-                    82195281,
-                ])),
+                value: Numeric("82195281"),
             ),
             (
                 name: "idx_markets_originator",
-                value: Address("tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6"),
+                value: String("tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6"),
             ),
             (
                 name: "noname",
-                value: Unit(Some("storage.liquidity_provider_map.bet")),
+                value: String("storage.liquidity_provider_map.bet"),
             ),
         ],
     ),
@@ -161,21 +139,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    236,
-                ])),
+                value: Int(236),
             ),
             (
                 name: "bet_quantity",
-                value: Int((1, [
-                    500000000,
-                ])),
+                value: Numeric("500000000"),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Int((1, [
-                    38000000,
-                ])),
+                value: Numeric("38000000"),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228524-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228524-inserts.json
@@ -31,7 +31,7 @@
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Numeric("82195281"),
+                value: Numeric(Some("82195281")),
             ),
             (
                 name: "state",
@@ -87,15 +87,15 @@
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Numeric("94999999740100000"),
+                value: Numeric(Some("94999999740100000")),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Numeric("95000000002500000"),
+                value: Numeric(Some("95000000002500000")),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Numeric("2500100000"),
+                value: Numeric(Some("2500100000")),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -117,7 +117,7 @@
             ),
             (
                 name: "idx_markets_market_id",
-                value: Numeric("82195281"),
+                value: Numeric(Some("82195281")),
             ),
             (
                 name: "idx_markets_originator",
@@ -143,11 +143,11 @@
             ),
             (
                 name: "bet_quantity",
-                value: Numeric("500100000"),
+                value: Numeric(Some("500100000")),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Numeric("37992401"),
+                value: Numeric(Some("37992401")),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228524-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228524-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    248,
-                ])),
+                value: Int(248),
             ),
             (
                 name: "deleted",
@@ -29,27 +27,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    248,
-                ])),
+                value: Int(248),
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Int((1, [
-                    82195281,
-                ])),
+                value: Numeric("82195281"),
             ),
             (
                 name: "state",
-                value: Unit(Some("storage.market_map.auctionRunning")),
+                value: String("storage.market_map.auctionRunning"),
             ),
             (
                 name: "currency",
-                value: Unit(Some("metadata_fa12")),
+                value: String("metadata_fa12"),
             ),
             (
                 name: "metadata_adjudicator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "metadata_description",
@@ -71,13 +65,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    248,
-                ])),
+                value: Int(248),
             ),
             (
                 name: "metadata_fa12",
-                value: Address("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
+                value: String("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
             ),
         ],
     ),
@@ -91,29 +83,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    248,
-                ])),
+                value: Int(248),
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Int((1, [
-                    371965344,
-                    22118911,
-                ])),
+                value: Numeric("94999999740100000"),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Int((1, [
-                    634365344,
-                    22118911,
-                ])),
+                value: Numeric("95000000002500000"),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Int((1, [
-                    2500100000,
-                ])),
+                value: Numeric("2500100000"),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -131,23 +113,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    248,
-                ])),
+                value: Int(248),
             ),
             (
                 name: "idx_markets_market_id",
-                value: Int((1, [
-                    82195281,
-                ])),
+                value: Numeric("82195281"),
             ),
             (
                 name: "idx_markets_originator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "noname",
-                value: Unit(Some("storage.liquidity_provider_map.bet")),
+                value: String("storage.liquidity_provider_map.bet"),
             ),
         ],
     ),
@@ -161,21 +139,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    248,
-                ])),
+                value: Int(248),
             ),
             (
                 name: "bet_quantity",
-                value: Int((1, [
-                    500100000,
-                ])),
+                value: Numeric("500100000"),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Int((1, [
-                    37992401,
-                ])),
+                value: Numeric("37992401"),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228525-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228525-inserts.json
@@ -31,7 +31,7 @@
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Numeric("82195281"),
+                value: Numeric(Some("82195281")),
             ),
             (
                 name: "state",
@@ -87,15 +87,15 @@
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Numeric("113999999740100000"),
+                value: Numeric(Some("113999999740100000")),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Numeric("114000000002500000"),
+                value: Numeric(Some("114000000002500000")),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Numeric("3000100000"),
+                value: Numeric(Some("3000100000")),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -117,7 +117,7 @@
             ),
             (
                 name: "idx_markets_market_id",
-                value: Numeric("82195281"),
+                value: Numeric(Some("82195281")),
             ),
             (
                 name: "idx_markets_originator",
@@ -143,11 +143,11 @@
             ),
             (
                 name: "bet_quantity",
-                value: Numeric("500000000"),
+                value: Numeric(Some("500000000")),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Numeric("38000000"),
+                value: Numeric(Some("38000000")),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228525-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228525-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    260,
-                ])),
+                value: Int(260),
             ),
             (
                 name: "deleted",
@@ -29,27 +27,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    260,
-                ])),
+                value: Int(260),
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Int((1, [
-                    82195281,
-                ])),
+                value: Numeric("82195281"),
             ),
             (
                 name: "state",
-                value: Unit(Some("storage.market_map.auctionRunning")),
+                value: String("storage.market_map.auctionRunning"),
             ),
             (
                 name: "currency",
-                value: Unit(Some("metadata_fa12")),
+                value: String("metadata_fa12"),
             ),
             (
                 name: "metadata_adjudicator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "metadata_description",
@@ -71,13 +65,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    260,
-                ])),
+                value: Int(260),
             ),
             (
                 name: "metadata_fa12",
-                value: Address("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
+                value: String("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
             ),
         ],
     ),
@@ -91,29 +83,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    260,
-                ])),
+                value: Int(260),
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Int((1, [
-                    1357331872,
-                    26542693,
-                ])),
+                value: Numeric("113999999740100000"),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Int((1, [
-                    1619731872,
-                    26542693,
-                ])),
+                value: Numeric("114000000002500000"),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Int((1, [
-                    3000100000,
-                ])),
+                value: Numeric("3000100000"),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -131,23 +113,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    260,
-                ])),
+                value: Int(260),
             ),
             (
                 name: "idx_markets_market_id",
-                value: Int((1, [
-                    82195281,
-                ])),
+                value: Numeric("82195281"),
             ),
             (
                 name: "idx_markets_originator",
-                value: Address("tz1LQn3AuoxRVwBsb3rVLQ56nRvC3JqNgVxR"),
+                value: String("tz1LQn3AuoxRVwBsb3rVLQ56nRvC3JqNgVxR"),
             ),
             (
                 name: "noname",
-                value: Unit(Some("storage.liquidity_provider_map.bet")),
+                value: String("storage.liquidity_provider_map.bet"),
             ),
         ],
     ),
@@ -161,21 +139,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    260,
-                ])),
+                value: Int(260),
             ),
             (
                 name: "bet_quantity",
-                value: Int((1, [
-                    500000000,
-                ])),
+                value: Numeric("500000000"),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Int((1, [
-                    38000000,
-                ])),
+                value: Numeric("38000000"),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228526-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228526-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    272,
-                ])),
+                value: Int(272),
             ),
             (
                 name: "deleted",
@@ -29,27 +27,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    272,
-                ])),
+                value: Int(272),
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Int((1, [
-                    82195281,
-                ])),
+                value: Numeric("82195281"),
             ),
             (
                 name: "state",
-                value: Unit(Some("storage.market_map.auctionRunning")),
+                value: String("storage.market_map.auctionRunning"),
             ),
             (
                 name: "currency",
-                value: Unit(Some("metadata_fa12")),
+                value: String("metadata_fa12"),
             ),
             (
                 name: "metadata_adjudicator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "metadata_description",
@@ -71,13 +65,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    272,
-                ])),
+                value: Int(272),
             ),
             (
                 name: "metadata_fa12",
-                value: Address("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
+                value: String("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
             ),
         ],
     ),
@@ -91,29 +83,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    272,
-                ])),
+                value: Int(272),
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Int((1, [
-                    2342698400,
-                    30966475,
-                ])),
+                value: Numeric("132999999740100000"),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Int((1, [
-                    2605098400,
-                    30966475,
-                ])),
+                value: Numeric("133000000002500000"),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Int((1, [
-                    3500100000,
-                ])),
+                value: Numeric("3500100000"),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -131,23 +113,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    272,
-                ])),
+                value: Int(272),
             ),
             (
                 name: "idx_markets_market_id",
-                value: Int((1, [
-                    82195281,
-                ])),
+                value: Numeric("82195281"),
             ),
             (
                 name: "idx_markets_originator",
-                value: Address("tz1Q3eT3kwr1hfvK49HK8YqPadNXzxdxnE7u"),
+                value: String("tz1Q3eT3kwr1hfvK49HK8YqPadNXzxdxnE7u"),
             ),
             (
                 name: "noname",
-                value: Unit(Some("storage.liquidity_provider_map.bet")),
+                value: String("storage.liquidity_provider_map.bet"),
             ),
         ],
     ),
@@ -161,21 +139,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    272,
-                ])),
+                value: Int(272),
             ),
             (
                 name: "bet_quantity",
-                value: Int((1, [
-                    500000000,
-                ])),
+                value: Numeric("500000000"),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Int((1, [
-                    38000000,
-                ])),
+                value: Numeric("38000000"),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228526-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228526-inserts.json
@@ -31,7 +31,7 @@
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Numeric("82195281"),
+                value: Numeric(Some("82195281")),
             ),
             (
                 name: "state",
@@ -87,15 +87,15 @@
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Numeric("132999999740100000"),
+                value: Numeric(Some("132999999740100000")),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Numeric("133000000002500000"),
+                value: Numeric(Some("133000000002500000")),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Numeric("3500100000"),
+                value: Numeric(Some("3500100000")),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -117,7 +117,7 @@
             ),
             (
                 name: "idx_markets_market_id",
-                value: Numeric("82195281"),
+                value: Numeric(Some("82195281")),
             ),
             (
                 name: "idx_markets_originator",
@@ -143,11 +143,11 @@
             ),
             (
                 name: "bet_quantity",
-                value: Numeric("500000000"),
+                value: Numeric(Some("500000000")),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Numeric("38000000"),
+                value: Numeric(Some("38000000")),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228527-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228527-inserts.json
@@ -31,7 +31,7 @@
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Numeric("82195281"),
+                value: Numeric(Some("82195281")),
             ),
             (
                 name: "state",
@@ -87,15 +87,15 @@
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Numeric("151999999740100000"),
+                value: Numeric(Some("151999999740100000")),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Numeric("152000000002500000"),
+                value: Numeric(Some("152000000002500000")),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Numeric("4000100000"),
+                value: Numeric(Some("4000100000")),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -117,7 +117,7 @@
             ),
             (
                 name: "idx_markets_market_id",
-                value: Numeric("82195281"),
+                value: Numeric(Some("82195281")),
             ),
             (
                 name: "idx_markets_originator",
@@ -143,11 +143,11 @@
             ),
             (
                 name: "bet_quantity",
-                value: Numeric("500000000"),
+                value: Numeric(Some("500000000")),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Numeric("38000000"),
+                value: Numeric(Some("38000000")),
             ),
         ],
     ),

--- a/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228527-inserts.json
+++ b/test/KT1McJxUCT8qAybMfS6n5kjaESsi7cFbfck8-228527-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    284,
-                ])),
+                value: Int(284),
             ),
             (
                 name: "deleted",
@@ -29,27 +27,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    284,
-                ])),
+                value: Int(284),
             ),
             (
                 name: "idx_markets_nat_4",
-                value: Int((1, [
-                    82195281,
-                ])),
+                value: Numeric("82195281"),
             ),
             (
                 name: "state",
-                value: Unit(Some("storage.market_map.auctionRunning")),
+                value: String("storage.market_map.auctionRunning"),
             ),
             (
                 name: "currency",
-                value: Unit(Some("metadata_fa12")),
+                value: String("metadata_fa12"),
             ),
             (
                 name: "metadata_adjudicator",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "metadata_description",
@@ -71,13 +65,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    284,
-                ])),
+                value: Int(284),
             ),
             (
                 name: "metadata_fa12",
-                value: Address("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
+                value: String("KT1EUHkuRmcXiaG2wqLh4LYGs9KzLKmm4XQr"),
             ),
         ],
     ),
@@ -91,29 +83,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    284,
-                ])),
+                value: Int(284),
             ),
             (
                 name: "auctionRunning_uniswap_contribution",
-                value: Int((1, [
-                    3328064928,
-                    35390257,
-                ])),
+                value: Numeric("151999999740100000"),
             ),
             (
                 name: "auctionRunning_yes_preference",
-                value: Int((1, [
-                    3590464928,
-                    35390257,
-                ])),
+                value: Numeric("152000000002500000"),
             ),
             (
                 name: "auctionRunning_quantity",
-                value: Int((1, [
-                    4000100000,
-                ])),
+                value: Numeric("4000100000"),
             ),
             (
                 name: "auctionRunning_auction_period_end",
@@ -131,23 +113,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    284,
-                ])),
+                value: Int(284),
             ),
             (
                 name: "idx_markets_market_id",
-                value: Int((1, [
-                    82195281,
-                ])),
+                value: Numeric("82195281"),
             ),
             (
                 name: "idx_markets_originator",
-                value: Address("tz1aHRZdotP9mVuPmzUcMAGmcTghTHfJLkZM"),
+                value: String("tz1aHRZdotP9mVuPmzUcMAGmcTghTHfJLkZM"),
             ),
             (
                 name: "noname",
-                value: Unit(Some("storage.liquidity_provider_map.bet")),
+                value: String("storage.liquidity_provider_map.bet"),
             ),
         ],
     ),
@@ -161,21 +139,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    284,
-                ])),
+                value: Int(284),
             ),
             (
                 name: "bet_quantity",
-                value: Int((1, [
-                    500000000,
-                ])),
+                value: Numeric("500000000"),
             ),
             (
                 name: "bet_predicted_probability",
-                value: Int((1, [
-                    38000000,
-                ])),
+                value: Numeric("38000000"),
             ),
         ],
     ),

--- a/test/KT1QxLqukyfohPV5kPkw97Rs6cw1DDDvYgbB-1443112-inserts.json
+++ b/test/KT1QxLqukyfohPV5kPkw97Rs6cw1DDDvYgbB-1443112-inserts.json
@@ -17,27 +17,27 @@
             ),
             (
                 name: "veto",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "total_votes",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "total_supply",
-                value: Numeric("42835649442"),
+                value: Numeric(Some("42835649442")),
             ),
             (
                 name: "total_reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "token_pool",
-                value: Numeric("14695349500"),
+                value: Numeric(Some("14695349500")),
             ),
             (
                 name: "token_id",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "token_address",
@@ -45,23 +45,23 @@
             ),
             (
                 name: "tez_pool",
-                value: Numeric("42835649442"),
+                value: Numeric(Some("42835649442")),
             ),
             (
                 name: "reward_per_share",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward_per_sec",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "period_finish",
@@ -99,11 +99,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -125,11 +125,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -151,11 +151,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -177,11 +177,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -203,11 +203,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -229,11 +229,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -255,11 +255,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -281,11 +281,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -307,11 +307,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -333,11 +333,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -359,11 +359,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -385,11 +385,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -411,11 +411,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -437,11 +437,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -463,11 +463,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -489,11 +489,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -515,11 +515,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -541,11 +541,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -567,11 +567,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -593,11 +593,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -619,11 +619,11 @@
             ),
             (
                 name: "reward_paid",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "reward",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -645,11 +645,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("15317873"),
+                value: Numeric(Some("15317873")),
             ),
         ],
     ),
@@ -671,11 +671,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("4050688"),
+                value: Numeric(Some("4050688")),
             ),
         ],
     ),
@@ -697,11 +697,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("10416557"),
+                value: Numeric(Some("10416557")),
             ),
         ],
     ),
@@ -723,11 +723,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("7822061"),
+                value: Numeric(Some("7822061")),
             ),
         ],
     ),
@@ -749,11 +749,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("53514154"),
+                value: Numeric(Some("53514154")),
             ),
         ],
     ),
@@ -775,11 +775,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("575337043"),
+                value: Numeric(Some("575337043")),
             ),
         ],
     ),
@@ -801,11 +801,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("347542068"),
+                value: Numeric(Some("347542068")),
             ),
         ],
     ),
@@ -827,11 +827,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("8664047"),
+                value: Numeric(Some("8664047")),
             ),
         ],
     ),
@@ -853,11 +853,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("9037230"),
+                value: Numeric(Some("9037230")),
             ),
         ],
     ),
@@ -879,11 +879,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("234558725"),
+                value: Numeric(Some("234558725")),
             ),
         ],
     ),
@@ -905,11 +905,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("40274210"),
+                value: Numeric(Some("40274210")),
             ),
         ],
     ),
@@ -931,11 +931,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("14432120"),
+                value: Numeric(Some("14432120")),
             ),
         ],
     ),
@@ -957,11 +957,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("172829188"),
+                value: Numeric(Some("172829188")),
             ),
         ],
     ),
@@ -983,11 +983,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("38347214663"),
+                value: Numeric(Some("38347214663")),
             ),
         ],
     ),
@@ -1009,11 +1009,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("4083947"),
+                value: Numeric(Some("4083947")),
             ),
         ],
     ),
@@ -1035,11 +1035,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("6535157"),
+                value: Numeric(Some("6535157")),
             ),
         ],
     ),
@@ -1061,11 +1061,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("6701439"),
+                value: Numeric(Some("6701439")),
             ),
         ],
     ),
@@ -1087,11 +1087,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("1388777449"),
+                value: Numeric(Some("1388777449")),
             ),
         ],
     ),
@@ -1113,11 +1113,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("1441746528"),
+                value: Numeric(Some("1441746528")),
             ),
         ],
     ),
@@ -1139,11 +1139,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("78270768"),
+                value: Numeric(Some("78270768")),
             ),
         ],
     ),
@@ -1165,11 +1165,11 @@
             ),
             (
                 name: "frozen_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
             (
                 name: "balance",
-                value: Numeric("68523527"),
+                value: Numeric(Some("68523527")),
             ),
         ],
     ),

--- a/test/KT1QxLqukyfohPV5kPkw97Rs6cw1DDDvYgbB-1443112-inserts.json
+++ b/test/KT1QxLqukyfohPV5kPkw97Rs6cw1DDDvYgbB-1443112-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "deleted",
@@ -19,60 +17,51 @@
             ),
             (
                 name: "veto",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "total_votes",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "total_supply",
-                value: Int((1, [
-                    4180943778,
-                    9,
-                ])),
+                value: Numeric("42835649442"),
             ),
             (
                 name: "total_reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "token_pool",
-                value: Int((1, [
-                    1810447612,
-                    3,
-                ])),
+                value: Numeric("14695349500"),
             ),
             (
                 name: "token_id",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "token_address",
-                value: Address("KT1AFA2mwNUMNd4SsujE1YYp29vd8BZejyKW"),
+                value: String("KT1AFA2mwNUMNd4SsujE1YYp29vd8BZejyKW"),
             ),
             (
                 name: "tez_pool",
-                value: Int((1, [
-                    4180943778,
-                    9,
-                ])),
+                value: Numeric("42835649442"),
             ),
             (
                 name: "reward_per_share",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward_per_sec",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "period_finish",
@@ -88,7 +77,7 @@
             ),
             (
                 name: "baker_validator",
-                value: Address("KT1Rowg7xjbQzQh3VFb2E9r6PMxoAqyJnSZi"),
+                value: String("KT1Rowg7xjbQzQh3VFb2E9r6PMxoAqyJnSZi"),
             ),
         ],
     ),
@@ -102,21 +91,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz2L3KjqXf8ZtvFz6TY2qxUzBxrYyeGCbugM"),
+                value: String("tz2L3KjqXf8ZtvFz6TY2qxUzBxrYyeGCbugM"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -130,21 +117,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz2KGfnYWeBd7xQYDCo52x22JbgXkK41Caiw"),
+                value: String("tz2KGfnYWeBd7xQYDCo52x22JbgXkK41Caiw"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -158,21 +143,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1ioU6W4otB7ebgRZTq1EVVra3vMyXqeqsm"),
+                value: String("tz1ioU6W4otB7ebgRZTq1EVVra3vMyXqeqsm"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -186,21 +169,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1gACjUSBkWjqWv5ZBMRk6G9Sp8xNAYgwYV"),
+                value: String("tz1gACjUSBkWjqWv5ZBMRk6G9Sp8xNAYgwYV"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -214,21 +195,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1fCCyqjcmwNw5Vv1b7yVXPvJzL42KqxWxd"),
+                value: String("tz1fCCyqjcmwNw5Vv1b7yVXPvJzL42KqxWxd"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -242,21 +221,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1dAFwciSCkzzQL2goqZyqucFyqVPmXzCkJ"),
+                value: String("tz1dAFwciSCkzzQL2goqZyqucFyqVPmXzCkJ"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -270,21 +247,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1c2e1WMKKtf6oBZcZK3YFxrXgVbb2ggRr9"),
+                value: String("tz1c2e1WMKKtf6oBZcZK3YFxrXgVbb2ggRr9"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -298,21 +273,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1bRDYJHp3ACUojEeM6Ja442YEwNmcb7ph9"),
+                value: String("tz1bRDYJHp3ACUojEeM6Ja442YEwNmcb7ph9"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -326,21 +299,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1ZWbokP5pGwT3tTtLPP2KhXX5ssg1EtDPs"),
+                value: String("tz1ZWbokP5pGwT3tTtLPP2KhXX5ssg1EtDPs"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -354,21 +325,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1YqsEWdPxBmqVKsJircrwBmCmZDtHAgHzp"),
+                value: String("tz1YqsEWdPxBmqVKsJircrwBmCmZDtHAgHzp"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -382,21 +351,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1YQDCB6Hbn2ozMyS2kf6WPJDeRvJtmtNqQ"),
+                value: String("tz1YQDCB6Hbn2ozMyS2kf6WPJDeRvJtmtNqQ"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -410,21 +377,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1Xy5UM1tC3CFcbPBVq5PjufaxcLjMwfQkE"),
+                value: String("tz1Xy5UM1tC3CFcbPBVq5PjufaxcLjMwfQkE"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -438,21 +403,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1X4epy6wnxhrYPQRaBYbhejzXuD6A4D3RW"),
+                value: String("tz1X4epy6wnxhrYPQRaBYbhejzXuD6A4D3RW"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -466,21 +429,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1WZkXCNbYj4jQtPtxUP1bxtw91YSpn5Lzk"),
+                value: String("tz1WZkXCNbYj4jQtPtxUP1bxtw91YSpn5Lzk"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -494,21 +455,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1W53nWnqavj4BEbv53zwLMVVTKVTs4gfkP"),
+                value: String("tz1W53nWnqavj4BEbv53zwLMVVTKVTs4gfkP"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -522,21 +481,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1VLGEhMhsb2HDhUaa2oeHQ8qM7Y7s72d3s"),
+                value: String("tz1VLGEhMhsb2HDhUaa2oeHQ8qM7Y7s72d3s"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -550,21 +507,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1UFF5DSDDtk3fM1ewaLvVG6fhaAeCdgYEt"),
+                value: String("tz1UFF5DSDDtk3fM1ewaLvVG6fhaAeCdgYEt"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -578,21 +533,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1TreKYWjXdKDaKCga4b8zobDq2pdHdGZuA"),
+                value: String("tz1TreKYWjXdKDaKCga4b8zobDq2pdHdGZuA"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -606,21 +559,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1RuvNyBmcB6shsv9WCruiifzFvnNHdvk1a"),
+                value: String("tz1RuvNyBmcB6shsv9WCruiifzFvnNHdvk1a"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -634,21 +585,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1RrNFg8Pm4WXEpzsrb6YeGZeib6moPn849"),
+                value: String("tz1RrNFg8Pm4WXEpzsrb6YeGZeib6moPn849"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -662,21 +611,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_6",
-                value: Address("tz1LHUdjqTGVigZoSSvq8CZpbeP1mTTYNmLk"),
+                value: String("tz1LHUdjqTGVigZoSSvq8CZpbeP1mTTYNmLk"),
             ),
             (
                 name: "reward_paid",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "reward",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -690,23 +637,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz2L3KjqXf8ZtvFz6TY2qxUzBxrYyeGCbugM"),
+                value: String("tz2L3KjqXf8ZtvFz6TY2qxUzBxrYyeGCbugM"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    15317873,
-                ])),
+                value: Numeric("15317873"),
             ),
         ],
     ),
@@ -720,23 +663,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz2KGfnYWeBd7xQYDCo52x22JbgXkK41Caiw"),
+                value: String("tz2KGfnYWeBd7xQYDCo52x22JbgXkK41Caiw"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    4050688,
-                ])),
+                value: Numeric("4050688"),
             ),
         ],
     ),
@@ -750,23 +689,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1ioU6W4otB7ebgRZTq1EVVra3vMyXqeqsm"),
+                value: String("tz1ioU6W4otB7ebgRZTq1EVVra3vMyXqeqsm"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    10416557,
-                ])),
+                value: Numeric("10416557"),
             ),
         ],
     ),
@@ -780,23 +715,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1gACjUSBkWjqWv5ZBMRk6G9Sp8xNAYgwYV"),
+                value: String("tz1gACjUSBkWjqWv5ZBMRk6G9Sp8xNAYgwYV"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    7822061,
-                ])),
+                value: Numeric("7822061"),
             ),
         ],
     ),
@@ -810,23 +741,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1fCCyqjcmwNw5Vv1b7yVXPvJzL42KqxWxd"),
+                value: String("tz1fCCyqjcmwNw5Vv1b7yVXPvJzL42KqxWxd"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    53514154,
-                ])),
+                value: Numeric("53514154"),
             ),
         ],
     ),
@@ -840,23 +767,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1dAFwciSCkzzQL2goqZyqucFyqVPmXzCkJ"),
+                value: String("tz1dAFwciSCkzzQL2goqZyqucFyqVPmXzCkJ"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    575337043,
-                ])),
+                value: Numeric("575337043"),
             ),
         ],
     ),
@@ -870,23 +793,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1c2e1WMKKtf6oBZcZK3YFxrXgVbb2ggRr9"),
+                value: String("tz1c2e1WMKKtf6oBZcZK3YFxrXgVbb2ggRr9"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    347542068,
-                ])),
+                value: Numeric("347542068"),
             ),
         ],
     ),
@@ -900,23 +819,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1bRDYJHp3ACUojEeM6Ja442YEwNmcb7ph9"),
+                value: String("tz1bRDYJHp3ACUojEeM6Ja442YEwNmcb7ph9"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    8664047,
-                ])),
+                value: Numeric("8664047"),
             ),
         ],
     ),
@@ -930,23 +845,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1ZWbokP5pGwT3tTtLPP2KhXX5ssg1EtDPs"),
+                value: String("tz1ZWbokP5pGwT3tTtLPP2KhXX5ssg1EtDPs"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    9037230,
-                ])),
+                value: Numeric("9037230"),
             ),
         ],
     ),
@@ -960,23 +871,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1YqsEWdPxBmqVKsJircrwBmCmZDtHAgHzp"),
+                value: String("tz1YqsEWdPxBmqVKsJircrwBmCmZDtHAgHzp"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    234558725,
-                ])),
+                value: Numeric("234558725"),
             ),
         ],
     ),
@@ -990,23 +897,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1YQDCB6Hbn2ozMyS2kf6WPJDeRvJtmtNqQ"),
+                value: String("tz1YQDCB6Hbn2ozMyS2kf6WPJDeRvJtmtNqQ"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    40274210,
-                ])),
+                value: Numeric("40274210"),
             ),
         ],
     ),
@@ -1020,23 +923,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1Xy5UM1tC3CFcbPBVq5PjufaxcLjMwfQkE"),
+                value: String("tz1Xy5UM1tC3CFcbPBVq5PjufaxcLjMwfQkE"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    14432120,
-                ])),
+                value: Numeric("14432120"),
             ),
         ],
     ),
@@ -1050,23 +949,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1X4epy6wnxhrYPQRaBYbhejzXuD6A4D3RW"),
+                value: String("tz1X4epy6wnxhrYPQRaBYbhejzXuD6A4D3RW"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    172829188,
-                ])),
+                value: Numeric("172829188"),
             ),
         ],
     ),
@@ -1080,24 +975,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1WZkXCNbYj4jQtPtxUP1bxtw91YSpn5Lzk"),
+                value: String("tz1WZkXCNbYj4jQtPtxUP1bxtw91YSpn5Lzk"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    3987476295,
-                    8,
-                ])),
+                value: Numeric("38347214663"),
             ),
         ],
     ),
@@ -1111,23 +1001,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1W53nWnqavj4BEbv53zwLMVVTKVTs4gfkP"),
+                value: String("tz1W53nWnqavj4BEbv53zwLMVVTKVTs4gfkP"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    4083947,
-                ])),
+                value: Numeric("4083947"),
             ),
         ],
     ),
@@ -1141,23 +1027,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1VLGEhMhsb2HDhUaa2oeHQ8qM7Y7s72d3s"),
+                value: String("tz1VLGEhMhsb2HDhUaa2oeHQ8qM7Y7s72d3s"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    6535157,
-                ])),
+                value: Numeric("6535157"),
             ),
         ],
     ),
@@ -1171,23 +1053,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1UFF5DSDDtk3fM1ewaLvVG6fhaAeCdgYEt"),
+                value: String("tz1UFF5DSDDtk3fM1ewaLvVG6fhaAeCdgYEt"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    6701439,
-                ])),
+                value: Numeric("6701439"),
             ),
         ],
     ),
@@ -1201,23 +1079,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1TreKYWjXdKDaKCga4b8zobDq2pdHdGZuA"),
+                value: String("tz1TreKYWjXdKDaKCga4b8zobDq2pdHdGZuA"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    1388777449,
-                ])),
+                value: Numeric("1388777449"),
             ),
         ],
     ),
@@ -1231,23 +1105,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1RuvNyBmcB6shsv9WCruiifzFvnNHdvk1a"),
+                value: String("tz1RuvNyBmcB6shsv9WCruiifzFvnNHdvk1a"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    1441746528,
-                ])),
+                value: Numeric("1441746528"),
             ),
         ],
     ),
@@ -1261,23 +1131,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1RrNFg8Pm4WXEpzsrb6YeGZeib6moPn849"),
+                value: String("tz1RrNFg8Pm4WXEpzsrb6YeGZeib6moPn849"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    78270768,
-                ])),
+                value: Numeric("78270768"),
             ),
         ],
     ),
@@ -1291,23 +1157,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_4",
-                value: Address("tz1LHUdjqTGVigZoSSvq8CZpbeP1mTTYNmLk"),
+                value: String("tz1LHUdjqTGVigZoSSvq8CZpbeP1mTTYNmLk"),
             ),
             (
                 name: "frozen_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
             (
                 name: "balance",
-                value: Int((1, [
-                    68523527,
-                ])),
+                value: Numeric("68523527"),
             ),
         ],
     ),
@@ -1321,13 +1183,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_5",
-                value: Address("another address\' allowance set"),
+                value: String("another address\' allowance set"),
             ),
         ],
     ),
@@ -1341,13 +1201,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_5",
-                value: Address("test :-)"),
+                value: String("test :-)"),
             ),
         ],
     ),
@@ -1361,13 +1219,11 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_address_5",
-                value: Address("test"),
+                value: String("test"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132201-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132201-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("3"),
+                value: Numeric(Some("3")),
             ),
         ],
     ),
@@ -43,11 +43,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("3"),
+                value: Numeric(Some("3")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -65,11 +65,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("2"),
+                value: Numeric(Some("2")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -87,11 +87,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("1"),
+                value: Numeric(Some("1")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -113,27 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Numeric("7000000000000001000000000000000000000"),
+                value: Numeric(Some("7000000000000001000000000000000000000")),
             ),
             (
                 name: "yes_preference",
-                value: Numeric("7000000000000001000000000000000000000"),
+                value: Numeric(Some("7000000000000001000000000000000000000")),
             ),
             (
                 name: "total_auction_quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Numeric("3"),
+                value: Numeric(Some("3")),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Numeric("2"),
+                value: Numeric(Some("2")),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Numeric("1"),
+                value: Numeric(Some("1")),
             ),
             (
                 name: "market_close",
@@ -171,15 +171,15 @@
             ),
             (
                 name: "total_token",
-                value: Numeric("7000000000000001000000000000000000000"),
+                value: Numeric(Some("7000000000000001000000000000000000000")),
             ),
             (
                 name: "quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "rate",
-                value: Numeric("70000000000000010"),
+                value: Numeric(Some("70000000000000010")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132201-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132201-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    13,
-                ])),
+                value: Int(13),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    3,
-                ])),
+                value: Numeric("3"),
             ),
         ],
     ),
@@ -43,19 +39,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    13,
-                ])),
+                value: Int(13),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    3,
-                ])),
+                value: Numeric("3"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -69,19 +61,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    13,
-                ])),
+                value: Int(13),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    2,
-                ])),
+                value: Numeric("2"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -95,19 +83,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    13,
-                ])),
+                value: Int(13),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Numeric("1"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -121,9 +105,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    13,
-                ])),
+                value: Int(13),
             ),
             (
                 name: "idx_string_0",
@@ -131,47 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Int((1, [
-                    3735027712,
-                    484116277,
-                    1652502990,
-                    88352421,
-                ])),
+                value: Numeric("7000000000000001000000000000000000000"),
             ),
             (
                 name: "yes_preference",
-                value: Int((1, [
-                    3735027712,
-                    484116277,
-                    1652502990,
-                    88352421,
-                ])),
+                value: Numeric("7000000000000001000000000000000000000"),
             ),
             (
                 name: "total_auction_quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Int((1, [
-                    3,
-                ])),
+                value: Numeric("3"),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Int((1, [
-                    2,
-                ])),
+                value: Numeric("2"),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Numeric("1"),
             ),
             (
                 name: "market_close",
@@ -187,7 +149,7 @@
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -201,37 +163,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    13,
-                ])),
+                value: Int(13),
             ),
             (
                 name: "idx_address_1",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "total_token",
-                value: Int((1, [
-                    3735027712,
-                    484116277,
-                    1652502990,
-                    88352421,
-                ])),
+                value: Numeric("7000000000000001000000000000000000000"),
             ),
             (
                 name: "quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "rate",
-                value: Int((1, [
-                    239534090,
-                    16298145,
-                ])),
+                value: Numeric("70000000000000010"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132211-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132211-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    25,
-                ])),
+                value: Int(25),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    3,
-                ])),
+                value: Numeric("3"),
             ),
         ],
     ),
@@ -43,23 +39,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    25,
-                ])),
+                value: Int(25),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    3,
-                ])),
+                value: Numeric("3"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((1, [
-                    263069707,
-                    3560716601,
-                    5,
-                ])),
+                value: Numeric("107526881720430108683"),
             ),
         ],
     ),
@@ -73,23 +61,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    25,
-                ])),
+                value: Int(25),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    2,
-                ])),
+                value: Numeric("2"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((1, [
-                    263069707,
-                    3560716601,
-                    5,
-                ])),
+                value: Numeric("107526881720430108683"),
             ),
         ],
     ),
@@ -103,23 +83,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    25,
-                ])),
+                value: Int(25),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Numeric("1"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
         ],
     ),
@@ -133,9 +105,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    25,
-                ])),
+                value: Int(25),
             ),
             (
                 name: "idx_string_0",
@@ -143,47 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Int((1, [
-                    3735027712,
-                    484116277,
-                    1652502990,
-                    88352421,
-                ])),
+                value: Numeric("7000000000000001000000000000000000000"),
             ),
             (
                 name: "yes_preference",
-                value: Int((1, [
-                    3735027712,
-                    484116277,
-                    1652502990,
-                    88352421,
-                ])),
+                value: Numeric("7000000000000001000000000000000000000"),
             ),
             (
                 name: "total_auction_quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Int((1, [
-                    3,
-                ])),
+                value: Numeric("3"),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Int((1, [
-                    2,
-                ])),
+                value: Numeric("2"),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Numeric("1"),
             ),
             (
                 name: "market_close",
@@ -199,7 +149,7 @@
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -213,37 +163,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    25,
-                ])),
+                value: Int(25),
             ),
             (
                 name: "idx_address_1",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "total_token",
-                value: Int((1, [
-                    3735027712,
-                    484116277,
-                    1652502990,
-                    88352421,
-                ])),
+                value: Numeric("7000000000000001000000000000000000000"),
             ),
             (
                 name: "quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "rate",
-                value: Int((1, [
-                    239534090,
-                    16298145,
-                ])),
+                value: Numeric("70000000000000010"),
             ),
         ],
     ),
@@ -257,26 +193,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    25,
-                ])),
+                value: Int(25),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    3,
-                ])),
+                value: Numeric("3"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
+                value: String("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    2896044043,
-                    1752488715,
-                ])),
+                value: Numeric("7526881720430108683"),
             ),
         ],
     ),
@@ -290,26 +219,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    25,
-                ])),
+                value: Int(25),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    2,
-                ])),
+                value: Numeric("2"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
+                value: String("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    2896044043,
-                    1752488715,
-                ])),
+                value: Numeric("7526881720430108683"),
             ),
         ],
     ),
@@ -323,27 +245,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    25,
-                ])),
+                value: Int(25),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Numeric("1"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
+                value: String("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
         ],
     ),
@@ -357,27 +271,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    25,
-                ])),
+                value: Int(25),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    3,
-                ])),
+                value: Numeric("3"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
         ],
     ),
@@ -391,27 +297,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    25,
-                ])),
+                value: Int(25),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    2,
-                ])),
+                value: Numeric("2"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132211-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132211-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("3"),
+                value: Numeric(Some("3")),
             ),
         ],
     ),
@@ -43,11 +43,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("3"),
+                value: Numeric(Some("3")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("107526881720430108683"),
+                value: Numeric(Some("107526881720430108683")),
             ),
         ],
     ),
@@ -65,11 +65,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("2"),
+                value: Numeric(Some("2")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("107526881720430108683"),
+                value: Numeric(Some("107526881720430108683")),
             ),
         ],
     ),
@@ -87,11 +87,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("1"),
+                value: Numeric(Some("1")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
         ],
     ),
@@ -113,27 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Numeric("7000000000000001000000000000000000000"),
+                value: Numeric(Some("7000000000000001000000000000000000000")),
             ),
             (
                 name: "yes_preference",
-                value: Numeric("7000000000000001000000000000000000000"),
+                value: Numeric(Some("7000000000000001000000000000000000000")),
             ),
             (
                 name: "total_auction_quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Numeric("3"),
+                value: Numeric(Some("3")),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Numeric("2"),
+                value: Numeric(Some("2")),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Numeric("1"),
+                value: Numeric(Some("1")),
             ),
             (
                 name: "market_close",
@@ -171,15 +171,15 @@
             ),
             (
                 name: "total_token",
-                value: Numeric("7000000000000001000000000000000000000"),
+                value: Numeric(Some("7000000000000001000000000000000000000")),
             ),
             (
                 name: "quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "rate",
-                value: Numeric("70000000000000010"),
+                value: Numeric(Some("70000000000000010")),
             ),
         ],
     ),
@@ -197,7 +197,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("3"),
+                value: Numeric(Some("3")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -205,7 +205,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("7526881720430108683"),
+                value: Numeric(Some("7526881720430108683")),
             ),
         ],
     ),
@@ -223,7 +223,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("2"),
+                value: Numeric(Some("2")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -231,7 +231,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("7526881720430108683"),
+                value: Numeric(Some("7526881720430108683")),
             ),
         ],
     ),
@@ -249,7 +249,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("1"),
+                value: Numeric(Some("1")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -257,7 +257,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
         ],
     ),
@@ -275,7 +275,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("3"),
+                value: Numeric(Some("3")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -283,7 +283,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
         ],
     ),
@@ -301,7 +301,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("2"),
+                value: Numeric(Some("2")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -309,7 +309,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132219-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132219-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    47,
-                ])),
+                value: Int(47),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    6,
-                ])),
+                value: Numeric("6"),
             ),
         ],
     ),
@@ -43,19 +39,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    47,
-                ])),
+                value: Int(47),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    6,
-                ])),
+                value: Numeric("6"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -69,19 +61,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    47,
-                ])),
+                value: Int(47),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    5,
-                ])),
+                value: Numeric("5"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -95,19 +83,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    47,
-                ])),
+                value: Int(47),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    4,
-                ])),
+                value: Numeric("4"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -121,9 +105,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    47,
-                ])),
+                value: Int(47),
             ),
             (
                 name: "idx_string_0",
@@ -131,47 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Int((1, [
-                    0,
-                    2155486032,
-                    1793925996,
-                    63108872,
-                ])),
+                value: Numeric("5000000000000000000000000000000000000"),
             ),
             (
                 name: "yes_preference",
-                value: Int((1, [
-                    0,
-                    2299528944,
-                    4019822861,
-                    1199068575,
-                ])),
+                value: Numeric("95000000000000000000000000000000000000"),
             ),
             (
                 name: "total_auction_quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Int((1, [
-                    6,
-                ])),
+                value: Numeric("6"),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Int((1, [
-                    5,
-                ])),
+                value: Numeric("5"),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Int((1, [
-                    4,
-                ])),
+                value: Numeric("4"),
             ),
             (
                 name: "market_close",
@@ -187,7 +149,7 @@
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -201,37 +163,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    47,
-                ])),
+                value: Int(47),
             ),
             (
                 name: "idx_address_1",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "total_token",
-                value: Int((1, [
-                    0,
-                    2299528944,
-                    4019822861,
-                    1199068575,
-                ])),
+                value: Numeric("95000000000000000000000000000000000000"),
             ),
             (
                 name: "quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "rate",
-                value: Int((1, [
-                    2023686144,
-                    221189111,
-                ])),
+                value: Numeric("950000000000000000"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132219-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132219-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("6"),
+                value: Numeric(Some("6")),
             ),
         ],
     ),
@@ -43,11 +43,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("6"),
+                value: Numeric(Some("6")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -65,11 +65,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("5"),
+                value: Numeric(Some("5")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -87,11 +87,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("4"),
+                value: Numeric(Some("4")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -113,27 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Numeric("5000000000000000000000000000000000000"),
+                value: Numeric(Some("5000000000000000000000000000000000000")),
             ),
             (
                 name: "yes_preference",
-                value: Numeric("95000000000000000000000000000000000000"),
+                value: Numeric(Some("95000000000000000000000000000000000000")),
             ),
             (
                 name: "total_auction_quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Numeric("6"),
+                value: Numeric(Some("6")),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Numeric("5"),
+                value: Numeric(Some("5")),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Numeric("4"),
+                value: Numeric(Some("4")),
             ),
             (
                 name: "market_close",
@@ -171,15 +171,15 @@
             ),
             (
                 name: "total_token",
-                value: Numeric("95000000000000000000000000000000000000"),
+                value: Numeric(Some("95000000000000000000000000000000000000")),
             ),
             (
                 name: "quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "rate",
-                value: Numeric("950000000000000000"),
+                value: Numeric(Some("950000000000000000")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132222-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132222-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("6"),
+                value: Numeric(Some("6")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132222-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132222-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    59,
-                ])),
+                value: Int(59),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    6,
-                ])),
+                value: Numeric("6"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132240-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132240-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("6"),
+                value: Numeric(Some("6")),
             ),
         ],
     ),
@@ -43,11 +43,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("6"),
+                value: Numeric(Some("6")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("105263157894736842105"),
+                value: Numeric(Some("105263157894736842105")),
             ),
         ],
     ),
@@ -65,11 +65,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("5"),
+                value: Numeric(Some("5")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
         ],
     ),
@@ -87,11 +87,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("4"),
+                value: Numeric(Some("4")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("105263157894736842105"),
+                value: Numeric(Some("105263157894736842105")),
             ),
         ],
     ),
@@ -113,27 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Numeric("5000000000000000000000000000000000000"),
+                value: Numeric(Some("5000000000000000000000000000000000000")),
             ),
             (
                 name: "yes_preference",
-                value: Numeric("95000000000000000000000000000000000000"),
+                value: Numeric(Some("95000000000000000000000000000000000000")),
             ),
             (
                 name: "total_auction_quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Numeric("6"),
+                value: Numeric(Some("6")),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Numeric("5"),
+                value: Numeric(Some("5")),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Numeric("4"),
+                value: Numeric(Some("4")),
             ),
             (
                 name: "market_close",
@@ -171,15 +171,15 @@
             ),
             (
                 name: "total_token",
-                value: Numeric("95000000000000000000000000000000000000"),
+                value: Numeric(Some("95000000000000000000000000000000000000")),
             ),
             (
                 name: "quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "rate",
-                value: Numeric("950000000000000000"),
+                value: Numeric(Some("950000000000000000")),
             ),
         ],
     ),
@@ -197,7 +197,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("6"),
+                value: Numeric(Some("6")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -205,7 +205,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("5263157894736842105"),
+                value: Numeric(Some("5263157894736842105")),
             ),
         ],
     ),
@@ -223,7 +223,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("5"),
+                value: Numeric(Some("5")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -231,7 +231,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
         ],
     ),
@@ -249,7 +249,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("4"),
+                value: Numeric(Some("4")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -257,7 +257,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("5263157894736842105"),
+                value: Numeric(Some("5263157894736842105")),
             ),
         ],
     ),
@@ -275,7 +275,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("6"),
+                value: Numeric(Some("6")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -283,7 +283,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
         ],
     ),
@@ -301,7 +301,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("4"),
+                value: Numeric(Some("4")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -309,7 +309,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132240-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132240-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    66,
-                ])),
+                value: Int(66),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    6,
-                ])),
+                value: Numeric("6"),
             ),
         ],
     ),
@@ -43,23 +39,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    66,
-                ])),
+                value: Int(66),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    6,
-                ])),
+                value: Numeric("6"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((1, [
-                    2879720825,
-                    3033652325,
-                    5,
-                ])),
+                value: Numeric("105263157894736842105"),
             ),
         ],
     ),
@@ -73,23 +61,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    66,
-                ])),
+                value: Int(66),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    5,
-                ])),
+                value: Numeric("5"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
         ],
     ),
@@ -103,23 +83,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    66,
-                ])),
+                value: Int(66),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    4,
-                ])),
+                value: Numeric("4"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((1, [
-                    2879720825,
-                    3033652325,
-                    5,
-                ])),
+                value: Numeric("105263157894736842105"),
             ),
         ],
     ),
@@ -133,9 +105,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    66,
-                ])),
+                value: Int(66),
             ),
             (
                 name: "idx_string_0",
@@ -143,47 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Int((1, [
-                    0,
-                    2155486032,
-                    1793925996,
-                    63108872,
-                ])),
+                value: Numeric("5000000000000000000000000000000000000"),
             ),
             (
                 name: "yes_preference",
-                value: Int((1, [
-                    0,
-                    2299528944,
-                    4019822861,
-                    1199068575,
-                ])),
+                value: Numeric("95000000000000000000000000000000000000"),
             ),
             (
                 name: "total_auction_quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Int((1, [
-                    6,
-                ])),
+                value: Numeric("6"),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Int((1, [
-                    5,
-                ])),
+                value: Numeric("5"),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Int((1, [
-                    4,
-                ])),
+                value: Numeric("4"),
             ),
             (
                 name: "market_close",
@@ -199,7 +149,7 @@
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -213,37 +163,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    66,
-                ])),
+                value: Int(66),
             ),
             (
                 name: "idx_address_1",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "total_token",
-                value: Int((1, [
-                    0,
-                    2299528944,
-                    4019822861,
-                    1199068575,
-                ])),
+                value: Numeric("95000000000000000000000000000000000000"),
             ),
             (
                 name: "quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "rate",
-                value: Int((1, [
-                    2023686144,
-                    221189111,
-                ])),
+                value: Numeric("950000000000000000"),
             ),
         ],
     ),
@@ -257,26 +193,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    66,
-                ])),
+                value: Int(66),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    6,
-                ])),
+                value: Numeric("6"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
+                value: String("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    1217727865,
-                    1225424440,
-                ])),
+                value: Numeric("5263157894736842105"),
             ),
         ],
     ),
@@ -290,27 +219,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    66,
-                ])),
+                value: Int(66),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    5,
-                ])),
+                value: Numeric("5"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
+                value: String("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
         ],
     ),
@@ -324,26 +245,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    66,
-                ])),
+                value: Int(66),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    4,
-                ])),
+                value: Numeric("4"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
+                value: String("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    1217727865,
-                    1225424440,
-                ])),
+                value: Numeric("5263157894736842105"),
             ),
         ],
     ),
@@ -357,27 +271,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    66,
-                ])),
+                value: Int(66),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    6,
-                ])),
+                value: Numeric("6"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
         ],
     ),
@@ -391,27 +297,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    66,
-                ])),
+                value: Int(66),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    4,
-                ])),
+                value: Numeric("4"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132242-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132242-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("6"),
+                value: Numeric(Some("6")),
             ),
         ],
     ),
@@ -47,31 +47,31 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Numeric("5000000000000000000000000000000000000"),
+                value: Numeric(Some("5000000000000000000000000000000000000")),
             ),
             (
                 name: "yes_preference",
-                value: Numeric("95000000000000000000000000000000000000"),
+                value: Numeric(Some("95000000000000000000000000000000000000")),
             ),
             (
                 name: "total_auction_quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "winning_token",
-                value: Numeric("5"),
+                value: Numeric(Some("5")),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Numeric("6"),
+                value: Numeric(Some("6")),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Numeric("5"),
+                value: Numeric(Some("5")),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Numeric("4"),
+                value: Numeric(Some("4")),
             ),
             (
                 name: "market_close",
@@ -109,15 +109,15 @@
             ),
             (
                 name: "total_token",
-                value: Numeric("95000000000000000000000000000000000000"),
+                value: Numeric(Some("95000000000000000000000000000000000000")),
             ),
             (
                 name: "quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "rate",
-                value: Numeric("950000000000000000"),
+                value: Numeric(Some("950000000000000000")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132242-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132242-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    88,
-                ])),
+                value: Int(88),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    6,
-                ])),
+                value: Numeric("6"),
             ),
         ],
     ),
@@ -43,9 +39,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    88,
-                ])),
+                value: Int(88),
             ),
             (
                 name: "idx_string_0",
@@ -53,53 +47,31 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Int((1, [
-                    0,
-                    2155486032,
-                    1793925996,
-                    63108872,
-                ])),
+                value: Numeric("5000000000000000000000000000000000000"),
             ),
             (
                 name: "yes_preference",
-                value: Int((1, [
-                    0,
-                    2299528944,
-                    4019822861,
-                    1199068575,
-                ])),
+                value: Numeric("95000000000000000000000000000000000000"),
             ),
             (
                 name: "total_auction_quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "winning_token",
-                value: Int((1, [
-                    5,
-                ])),
+                value: Numeric("5"),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Int((1, [
-                    6,
-                ])),
+                value: Numeric("6"),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Int((1, [
-                    5,
-                ])),
+                value: Numeric("5"),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Int((1, [
-                    4,
-                ])),
+                value: Numeric("4"),
             ),
             (
                 name: "market_close",
@@ -115,7 +87,7 @@
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -129,37 +101,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    88,
-                ])),
+                value: Int(88),
             ),
             (
                 name: "idx_address_1",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "total_token",
-                value: Int((1, [
-                    0,
-                    2299528944,
-                    4019822861,
-                    1199068575,
-                ])),
+                value: Numeric("95000000000000000000000000000000000000"),
             ),
             (
                 name: "quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "rate",
-                value: Int((1, [
-                    2023686144,
-                    221189111,
-                ])),
+                value: Numeric("950000000000000000"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132259-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132259-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("6"),
+                value: Numeric(Some("6")),
             ),
         ],
     ),
@@ -43,11 +43,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("6"),
+                value: Numeric(Some("6")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("5263157894736842105"),
+                value: Numeric(Some("5263157894736842105")),
             ),
         ],
     ),
@@ -65,7 +65,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("6"),
+                value: Numeric(Some("6")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -73,7 +73,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -91,7 +91,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("5"),
+                value: Numeric(Some("5")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -99,7 +99,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132259-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132259-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    97,
-                ])),
+                value: Int(97),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    6,
-                ])),
+                value: Numeric("6"),
             ),
         ],
     ),
@@ -43,22 +39,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    97,
-                ])),
+                value: Int(97),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    6,
-                ])),
+                value: Numeric("6"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((1, [
-                    1217727865,
-                    1225424440,
-                ])),
+                value: Numeric("5263157894736842105"),
             ),
         ],
     ),
@@ -72,23 +61,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    97,
-                ])),
+                value: Int(97),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    6,
-                ])),
+                value: Numeric("6"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -102,23 +87,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    97,
-                ])),
+                value: Int(97),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    5,
-                ])),
+                value: Numeric("5"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132262-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132262-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    109,
-                ])),
+                value: Int(109),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    6,
-                ])),
+                value: Numeric("6"),
             ),
         ],
     ),
@@ -43,22 +39,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    109,
-                ])),
+                value: Int(109),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    6,
-                ])),
+                value: Numeric("6"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((1, [
-                    1217727865,
-                    1225424440,
-                ])),
+                value: Numeric("5263157894736842105"),
             ),
         ],
     ),
@@ -72,23 +61,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    109,
-                ])),
+                value: Int(109),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    6,
-                ])),
+                value: Numeric("6"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -102,23 +87,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    109,
-                ])),
+                value: Int(109),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    5,
-                ])),
+                value: Numeric("5"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132262-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132262-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("6"),
+                value: Numeric(Some("6")),
             ),
         ],
     ),
@@ -43,11 +43,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("6"),
+                value: Numeric(Some("6")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("5263157894736842105"),
+                value: Numeric(Some("5263157894736842105")),
             ),
         ],
     ),
@@ -65,7 +65,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("6"),
+                value: Numeric(Some("6")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -73,7 +73,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -91,7 +91,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("5"),
+                value: Numeric(Some("5")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -99,7 +99,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132278-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132278-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("9"),
+                value: Numeric(Some("9")),
             ),
         ],
     ),
@@ -43,11 +43,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("9"),
+                value: Numeric(Some("9")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -65,11 +65,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("8"),
+                value: Numeric(Some("8")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -87,11 +87,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("7"),
+                value: Numeric(Some("7")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -113,27 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Numeric("7000000000000000000000000000000000000"),
+                value: Numeric(Some("7000000000000000000000000000000000000")),
             ),
             (
                 name: "yes_preference",
-                value: Numeric("93000000000000000000000000000000000000"),
+                value: Numeric(Some("93000000000000000000000000000000000000")),
             ),
             (
                 name: "total_auction_quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Numeric("9"),
+                value: Numeric(Some("9")),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Numeric("8"),
+                value: Numeric(Some("8")),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Numeric("7"),
+                value: Numeric(Some("7")),
             ),
             (
                 name: "market_close",
@@ -171,15 +171,15 @@
             ),
             (
                 name: "total_token",
-                value: Numeric("93000000000000000000000000000000000000"),
+                value: Numeric(Some("93000000000000000000000000000000000000")),
             ),
             (
                 name: "quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "rate",
-                value: Numeric("930000000000000000"),
+                value: Numeric(Some("930000000000000000")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132278-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132278-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    121,
-                ])),
+                value: Int(121),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    9,
-                ])),
+                value: Numeric("9"),
             ),
         ],
     ),
@@ -43,19 +39,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    121,
-                ])),
+                value: Int(121),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    9,
-                ])),
+                value: Numeric("9"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -69,19 +61,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    121,
-                ])),
+                value: Int(121),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    8,
-                ])),
+                value: Numeric("8"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -95,19 +83,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    121,
-                ])),
+                value: Int(121),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    7,
-                ])),
+                value: Numeric("7"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -121,9 +105,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    121,
-                ])),
+                value: Int(121),
             ),
             (
                 name: "idx_string_0",
@@ -131,47 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Int((1, [
-                    0,
-                    3876673904,
-                    1652502935,
-                    88352421,
-                ])),
+                value: Numeric("7000000000000000000000000000000000000"),
             ),
             (
                 name: "yes_preference",
-                value: Int((1, [
-                    0,
-                    578341072,
-                    4161245922,
-                    1173825026,
-                ])),
+                value: Numeric("93000000000000000000000000000000000000"),
             ),
             (
                 name: "total_auction_quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Int((1, [
-                    9,
-                ])),
+                value: Numeric("9"),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Int((1, [
-                    8,
-                ])),
+                value: Numeric("8"),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Int((1, [
-                    7,
-                ])),
+                value: Numeric("7"),
             ),
             (
                 name: "market_close",
@@ -187,7 +149,7 @@
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -201,37 +163,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    121,
-                ])),
+                value: Int(121),
             ),
             (
                 name: "idx_address_1",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "total_token",
-                value: Int((1, [
-                    0,
-                    578341072,
-                    4161245922,
-                    1173825026,
-                ])),
+                value: Numeric("93000000000000000000000000000000000000"),
             ),
             (
                 name: "quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "rate",
-                value: Int((1, [
-                    2568814592,
-                    216532498,
-                ])),
+                value: Numeric("930000000000000000"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132282-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132282-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("9"),
+                value: Numeric(Some("9")),
             ),
         ],
     ),
@@ -43,11 +43,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("9"),
+                value: Numeric(Some("9")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("107526881720430107526"),
+                value: Numeric(Some("107526881720430107526")),
             ),
         ],
     ),
@@ -65,11 +65,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("8"),
+                value: Numeric(Some("8")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
         ],
     ),
@@ -87,11 +87,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("7"),
+                value: Numeric(Some("7")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("107526881720430107526"),
+                value: Numeric(Some("107526881720430107526")),
             ),
         ],
     ),
@@ -113,27 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Numeric("7000000000000000000000000000000000000"),
+                value: Numeric(Some("7000000000000000000000000000000000000")),
             ),
             (
                 name: "yes_preference",
-                value: Numeric("93000000000000000000000000000000000000"),
+                value: Numeric(Some("93000000000000000000000000000000000000")),
             ),
             (
                 name: "total_auction_quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Numeric("9"),
+                value: Numeric(Some("9")),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Numeric("8"),
+                value: Numeric(Some("8")),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Numeric("7"),
+                value: Numeric(Some("7")),
             ),
             (
                 name: "market_close",
@@ -171,15 +171,15 @@
             ),
             (
                 name: "total_token",
-                value: Numeric("93000000000000000000000000000000000000"),
+                value: Numeric(Some("93000000000000000000000000000000000000")),
             ),
             (
                 name: "quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "rate",
-                value: Numeric("930000000000000000"),
+                value: Numeric(Some("930000000000000000")),
             ),
         ],
     ),
@@ -197,7 +197,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("9"),
+                value: Numeric(Some("9")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -205,7 +205,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("7526881720430107526"),
+                value: Numeric(Some("7526881720430107526")),
             ),
         ],
     ),
@@ -223,7 +223,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("8"),
+                value: Numeric(Some("8")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -231,7 +231,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
         ],
     ),
@@ -249,7 +249,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("7"),
+                value: Numeric(Some("7")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -257,7 +257,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("7526881720430107526"),
+                value: Numeric(Some("7526881720430107526")),
             ),
         ],
     ),
@@ -275,7 +275,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("9"),
+                value: Numeric(Some("9")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -283,7 +283,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
         ],
     ),
@@ -301,7 +301,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("7"),
+                value: Numeric(Some("7")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -309,7 +309,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132282-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132282-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    133,
-                ])),
+                value: Int(133),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    9,
-                ])),
+                value: Numeric("9"),
             ),
         ],
     ),
@@ -43,23 +39,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    133,
-                ])),
+                value: Int(133),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    9,
-                ])),
+                value: Numeric("9"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((1, [
-                    263068550,
-                    3560716601,
-                    5,
-                ])),
+                value: Numeric("107526881720430107526"),
             ),
         ],
     ),
@@ -73,23 +61,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    133,
-                ])),
+                value: Int(133),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    8,
-                ])),
+                value: Numeric("8"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
         ],
     ),
@@ -103,23 +83,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    133,
-                ])),
+                value: Int(133),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    7,
-                ])),
+                value: Numeric("7"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((1, [
-                    263068550,
-                    3560716601,
-                    5,
-                ])),
+                value: Numeric("107526881720430107526"),
             ),
         ],
     ),
@@ -133,9 +105,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    133,
-                ])),
+                value: Int(133),
             ),
             (
                 name: "idx_string_0",
@@ -143,47 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Int((1, [
-                    0,
-                    3876673904,
-                    1652502935,
-                    88352421,
-                ])),
+                value: Numeric("7000000000000000000000000000000000000"),
             ),
             (
                 name: "yes_preference",
-                value: Int((1, [
-                    0,
-                    578341072,
-                    4161245922,
-                    1173825026,
-                ])),
+                value: Numeric("93000000000000000000000000000000000000"),
             ),
             (
                 name: "total_auction_quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Int((1, [
-                    9,
-                ])),
+                value: Numeric("9"),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Int((1, [
-                    8,
-                ])),
+                value: Numeric("8"),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Int((1, [
-                    7,
-                ])),
+                value: Numeric("7"),
             ),
             (
                 name: "market_close",
@@ -199,7 +149,7 @@
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -213,37 +163,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    133,
-                ])),
+                value: Int(133),
             ),
             (
                 name: "idx_address_1",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "total_token",
-                value: Int((1, [
-                    0,
-                    578341072,
-                    4161245922,
-                    1173825026,
-                ])),
+                value: Numeric("93000000000000000000000000000000000000"),
             ),
             (
                 name: "quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "rate",
-                value: Int((1, [
-                    2568814592,
-                    216532498,
-                ])),
+                value: Numeric("930000000000000000"),
             ),
         ],
     ),
@@ -257,26 +193,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    133,
-                ])),
+                value: Int(133),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    9,
-                ])),
+                value: Numeric("9"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
+                value: String("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    2896042886,
-                    1752488715,
-                ])),
+                value: Numeric("7526881720430107526"),
             ),
         ],
     ),
@@ -290,27 +219,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    133,
-                ])),
+                value: Int(133),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    8,
-                ])),
+                value: Numeric("8"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
+                value: String("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
         ],
     ),
@@ -324,26 +245,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    133,
-                ])),
+                value: Int(133),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    7,
-                ])),
+                value: Numeric("7"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
+                value: String("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    2896042886,
-                    1752488715,
-                ])),
+                value: Numeric("7526881720430107526"),
             ),
         ],
     ),
@@ -357,27 +271,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    133,
-                ])),
+                value: Int(133),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    9,
-                ])),
+                value: Numeric("9"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
         ],
     ),
@@ -391,27 +297,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    133,
-                ])),
+                value: Int(133),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    7,
-                ])),
+                value: Numeric("7"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132285-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132285-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("9"),
+                value: Numeric(Some("9")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132285-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132285-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    155,
-                ])),
+                value: Int(155),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    9,
-                ])),
+                value: Numeric("9"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132298-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132298-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("9"),
+                value: Numeric(Some("9")),
             ),
         ],
     ),
@@ -47,31 +47,31 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Numeric("7000000000000000000000000000000000000"),
+                value: Numeric(Some("7000000000000000000000000000000000000")),
             ),
             (
                 name: "yes_preference",
-                value: Numeric("93000000000000000000000000000000000000"),
+                value: Numeric(Some("93000000000000000000000000000000000000")),
             ),
             (
                 name: "total_auction_quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "winning_token",
-                value: Numeric("7"),
+                value: Numeric(Some("7")),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Numeric("9"),
+                value: Numeric(Some("9")),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Numeric("8"),
+                value: Numeric(Some("8")),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Numeric("7"),
+                value: Numeric(Some("7")),
             ),
             (
                 name: "market_close",
@@ -109,15 +109,15 @@
             ),
             (
                 name: "total_token",
-                value: Numeric("93000000000000000000000000000000000000"),
+                value: Numeric(Some("93000000000000000000000000000000000000")),
             ),
             (
                 name: "quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "rate",
-                value: Numeric("930000000000000000"),
+                value: Numeric(Some("930000000000000000")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132298-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132298-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    162,
-                ])),
+                value: Int(162),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    9,
-                ])),
+                value: Numeric("9"),
             ),
         ],
     ),
@@ -43,9 +39,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    162,
-                ])),
+                value: Int(162),
             ),
             (
                 name: "idx_string_0",
@@ -53,53 +47,31 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Int((1, [
-                    0,
-                    3876673904,
-                    1652502935,
-                    88352421,
-                ])),
+                value: Numeric("7000000000000000000000000000000000000"),
             ),
             (
                 name: "yes_preference",
-                value: Int((1, [
-                    0,
-                    578341072,
-                    4161245922,
-                    1173825026,
-                ])),
+                value: Numeric("93000000000000000000000000000000000000"),
             ),
             (
                 name: "total_auction_quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "winning_token",
-                value: Int((1, [
-                    7,
-                ])),
+                value: Numeric("7"),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Int((1, [
-                    9,
-                ])),
+                value: Numeric("9"),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Int((1, [
-                    8,
-                ])),
+                value: Numeric("8"),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Int((1, [
-                    7,
-                ])),
+                value: Numeric("7"),
             ),
             (
                 name: "market_close",
@@ -115,7 +87,7 @@
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -129,37 +101,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    162,
-                ])),
+                value: Int(162),
             ),
             (
                 name: "idx_address_1",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "total_token",
-                value: Int((1, [
-                    0,
-                    578341072,
-                    4161245922,
-                    1173825026,
-                ])),
+                value: Numeric("93000000000000000000000000000000000000"),
             ),
             (
                 name: "quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "rate",
-                value: Int((1, [
-                    2568814592,
-                    216532498,
-                ])),
+                value: Numeric("930000000000000000"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132300-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132300-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    171,
-                ])),
+                value: Int(171),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    9,
-                ])),
+                value: Numeric("9"),
             ),
         ],
     ),
@@ -43,22 +39,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    171,
-                ])),
+                value: Int(171),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    9,
-                ])),
+                value: Numeric("9"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((1, [
-                    2896042886,
-                    1752488715,
-                ])),
+                value: Numeric("7526881720430107526"),
             ),
         ],
     ),
@@ -72,23 +61,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    171,
-                ])),
+                value: Int(171),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    9,
-                ])),
+                value: Numeric("9"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -102,23 +87,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    171,
-                ])),
+                value: Int(171),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    7,
-                ])),
+                value: Numeric("7"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132300-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132300-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("9"),
+                value: Numeric(Some("9")),
             ),
         ],
     ),
@@ -43,11 +43,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("9"),
+                value: Numeric(Some("9")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("7526881720430107526"),
+                value: Numeric(Some("7526881720430107526")),
             ),
         ],
     ),
@@ -65,7 +65,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("9"),
+                value: Numeric(Some("9")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -73,7 +73,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -91,7 +91,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("7"),
+                value: Numeric(Some("7")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -99,7 +99,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132343-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132343-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    12,
-                ])),
+                value: Numeric("12"),
             ),
         ],
     ),
@@ -43,22 +39,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    12,
-                ])),
+                value: Numeric("12"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((1, [
-                    1217727865,
-                    1225424440,
-                ])),
+                value: Numeric("5263157894736842105"),
             ),
         ],
     ),
@@ -72,23 +61,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    10,
-                ])),
+                value: Numeric("10"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -102,23 +87,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    1,
-                ])),
+                value: Int(1),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    12,
-                ])),
+                value: Numeric("12"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132343-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132343-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("12"),
+                value: Numeric(Some("12")),
             ),
         ],
     ),
@@ -43,11 +43,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("12"),
+                value: Numeric(Some("12")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("5263157894736842105"),
+                value: Numeric(Some("5263157894736842105")),
             ),
         ],
     ),
@@ -65,7 +65,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("10"),
+                value: Numeric(Some("10")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -73,7 +73,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -91,7 +91,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("12"),
+                value: Numeric(Some("12")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -99,7 +99,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132367-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132367-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    183,
-                ])),
+                value: Int(183),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    15,
-                ])),
+                value: Numeric("15"),
             ),
         ],
     ),
@@ -43,19 +39,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    183,
-                ])),
+                value: Int(183),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    15,
-                ])),
+                value: Numeric("15"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -69,19 +61,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    183,
-                ])),
+                value: Int(183),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    14,
-                ])),
+                value: Numeric("14"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -95,19 +83,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    183,
-                ])),
+                value: Int(183),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    13,
-                ])),
+                value: Numeric("13"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -121,9 +105,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    183,
-                ])),
+                value: Int(183),
             ),
             (
                 name: "idx_string_0",
@@ -131,47 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Int((1, [
-                    0,
-                    1302894480,
-                    1511079875,
-                    113595970,
-                ])),
+                value: Numeric("9000000000000000000000000000000000000"),
             ),
             (
                 name: "yes_preference",
-                value: Int((1, [
-                    0,
-                    3152120496,
-                    7701686,
-                    1148581478,
-                ])),
+                value: Numeric("91000000000000000000000000000000000000"),
             ),
             (
                 name: "total_auction_quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Int((1, [
-                    15,
-                ])),
+                value: Numeric("15"),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Int((1, [
-                    14,
-                ])),
+                value: Numeric("14"),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Int((1, [
-                    13,
-                ])),
+                value: Numeric("13"),
             ),
             (
                 name: "market_close",
@@ -187,7 +149,7 @@
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -201,37 +163,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    183,
-                ])),
+                value: Int(183),
             ),
             (
                 name: "idx_address_1",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "total_token",
-                value: Int((1, [
-                    0,
-                    3152120496,
-                    7701686,
-                    1148581478,
-                ])),
+                value: Numeric("91000000000000000000000000000000000000"),
             ),
             (
                 name: "quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "rate",
-                value: Int((1, [
-                    3113943040,
-                    211875885,
-                ])),
+                value: Numeric("910000000000000000"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132367-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132367-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("15"),
+                value: Numeric(Some("15")),
             ),
         ],
     ),
@@ -43,11 +43,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("15"),
+                value: Numeric(Some("15")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -65,11 +65,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("14"),
+                value: Numeric(Some("14")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -87,11 +87,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("13"),
+                value: Numeric(Some("13")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -113,27 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Numeric("9000000000000000000000000000000000000"),
+                value: Numeric(Some("9000000000000000000000000000000000000")),
             ),
             (
                 name: "yes_preference",
-                value: Numeric("91000000000000000000000000000000000000"),
+                value: Numeric(Some("91000000000000000000000000000000000000")),
             ),
             (
                 name: "total_auction_quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Numeric("15"),
+                value: Numeric(Some("15")),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Numeric("14"),
+                value: Numeric(Some("14")),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Numeric("13"),
+                value: Numeric(Some("13")),
             ),
             (
                 name: "market_close",
@@ -171,15 +171,15 @@
             ),
             (
                 name: "total_token",
-                value: Numeric("91000000000000000000000000000000000000"),
+                value: Numeric(Some("91000000000000000000000000000000000000")),
             ),
             (
                 name: "quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "rate",
-                value: Numeric("910000000000000000"),
+                value: Numeric(Some("910000000000000000")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132383-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132383-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("15"),
+                value: Numeric(Some("15")),
             ),
         ],
     ),
@@ -43,11 +43,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("15"),
+                value: Numeric(Some("15")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("109890109890109890109"),
+                value: Numeric(Some("109890109890109890109")),
             ),
         ],
     ),
@@ -65,11 +65,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("14"),
+                value: Numeric(Some("14")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
         ],
     ),
@@ -87,11 +87,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("13"),
+                value: Numeric(Some("13")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("9890109890109890109"),
+                value: Numeric(Some("9890109890109890109")),
             ),
         ],
     ),
@@ -113,27 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Numeric("9000000000000000000000000000000000000"),
+                value: Numeric(Some("9000000000000000000000000000000000000")),
             ),
             (
                 name: "yes_preference",
-                value: Numeric("91000000000000000000000000000000000000"),
+                value: Numeric(Some("91000000000000000000000000000000000000")),
             ),
             (
                 name: "total_auction_quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Numeric("15"),
+                value: Numeric(Some("15")),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Numeric("14"),
+                value: Numeric(Some("14")),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Numeric("13"),
+                value: Numeric(Some("13")),
             ),
             (
                 name: "market_close",
@@ -171,15 +171,15 @@
             ),
             (
                 name: "total_token",
-                value: Numeric("91000000000000000000000000000000000000"),
+                value: Numeric(Some("91000000000000000000000000000000000000")),
             ),
             (
                 name: "quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "rate",
-                value: Numeric("910000000000000000"),
+                value: Numeric(Some("910000000000000000")),
             ),
         ],
     ),
@@ -197,7 +197,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("15"),
+                value: Numeric(Some("15")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -205,7 +205,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("109890109890109890109"),
+                value: Numeric(Some("109890109890109890109")),
             ),
         ],
     ),
@@ -223,7 +223,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("14"),
+                value: Numeric(Some("14")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -231,7 +231,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
         ],
     ),
@@ -249,7 +249,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("13"),
+                value: Numeric(Some("13")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -257,7 +257,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("9890109890109890109"),
+                value: Numeric(Some("9890109890109890109")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132383-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132383-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    195,
-                ])),
+                value: Int(195),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    15,
-                ])),
+                value: Numeric("15"),
             ),
         ],
     ),
@@ -43,23 +39,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    195,
-                ])),
+                value: Int(195),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    15,
-                ])),
+                value: Numeric("15"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((1, [
-                    3903053373,
-                    4110948536,
-                    5,
-                ])),
+                value: Numeric("109890109890109890109"),
             ),
         ],
     ),
@@ -73,23 +61,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    195,
-                ])),
+                value: Int(195),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    14,
-                ])),
+                value: Numeric("14"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
         ],
     ),
@@ -103,22 +83,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    195,
-                ])),
+                value: Int(195),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    13,
-                ])),
+                value: Numeric("13"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((1, [
-                    2241060413,
-                    2302720651,
-                ])),
+                value: Numeric("9890109890109890109"),
             ),
         ],
     ),
@@ -132,9 +105,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    195,
-                ])),
+                value: Int(195),
             ),
             (
                 name: "idx_string_0",
@@ -142,47 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Int((1, [
-                    0,
-                    1302894480,
-                    1511079875,
-                    113595970,
-                ])),
+                value: Numeric("9000000000000000000000000000000000000"),
             ),
             (
                 name: "yes_preference",
-                value: Int((1, [
-                    0,
-                    3152120496,
-                    7701686,
-                    1148581478,
-                ])),
+                value: Numeric("91000000000000000000000000000000000000"),
             ),
             (
                 name: "total_auction_quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Int((1, [
-                    15,
-                ])),
+                value: Numeric("15"),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Int((1, [
-                    14,
-                ])),
+                value: Numeric("14"),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Int((1, [
-                    13,
-                ])),
+                value: Numeric("13"),
             ),
             (
                 name: "market_close",
@@ -198,7 +149,7 @@
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -212,37 +163,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    195,
-                ])),
+                value: Int(195),
             ),
             (
                 name: "idx_address_1",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "total_token",
-                value: Int((1, [
-                    0,
-                    3152120496,
-                    7701686,
-                    1148581478,
-                ])),
+                value: Numeric("91000000000000000000000000000000000000"),
             ),
             (
                 name: "quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "rate",
-                value: Int((1, [
-                    3113943040,
-                    211875885,
-                ])),
+                value: Numeric("910000000000000000"),
             ),
         ],
     ),
@@ -256,27 +193,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    195,
-                ])),
+                value: Int(195),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    15,
-                ])),
+                value: Numeric("15"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
+                value: String("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    3903053373,
-                    4110948536,
-                    5,
-                ])),
+                value: Numeric("109890109890109890109"),
             ),
         ],
     ),
@@ -290,27 +219,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    195,
-                ])),
+                value: Int(195),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    14,
-                ])),
+                value: Numeric("14"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
+                value: String("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
         ],
     ),
@@ -324,26 +245,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    195,
-                ])),
+                value: Int(195),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    13,
-                ])),
+                value: Numeric("13"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
+                value: String("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    2241060413,
-                    2302720651,
-                ])),
+                value: Numeric("9890109890109890109"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132384-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132384-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("15"),
+                value: Numeric(Some("15")),
             ),
         ],
     ),
@@ -43,11 +43,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("13"),
+                value: Numeric(Some("13")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("109890109890109890109"),
+                value: Numeric(Some("109890109890109890109")),
             ),
         ],
     ),
@@ -65,7 +65,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("15"),
+                value: Numeric(Some("15")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -73,7 +73,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("9890109890109890109"),
+                value: Numeric(Some("9890109890109890109")),
             ),
         ],
     ),
@@ -91,7 +91,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("15"),
+                value: Numeric(Some("15")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -99,7 +99,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
         ],
     ),
@@ -117,7 +117,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("13"),
+                value: Numeric(Some("13")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -125,7 +125,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132384-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132384-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    213,
-                ])),
+                value: Int(213),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    15,
-                ])),
+                value: Numeric("15"),
             ),
         ],
     ),
@@ -43,23 +39,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    213,
-                ])),
+                value: Int(213),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    13,
-                ])),
+                value: Numeric("13"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((1, [
-                    3903053373,
-                    4110948536,
-                    5,
-                ])),
+                value: Numeric("109890109890109890109"),
             ),
         ],
     ),
@@ -73,26 +61,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    213,
-                ])),
+                value: Int(213),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    15,
-                ])),
+                value: Numeric("15"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
+                value: String("KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    2241060413,
-                    2302720651,
-                ])),
+                value: Numeric("9890109890109890109"),
             ),
         ],
     ),
@@ -106,27 +87,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    213,
-                ])),
+                value: Int(213),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    15,
-                ])),
+                value: Numeric("15"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
         ],
     ),
@@ -140,27 +113,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    213,
-                ])),
+                value: Int(213),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    13,
-                ])),
+                value: Numeric("13"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132388-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132388-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("15"),
+                value: Numeric(Some("15")),
             ),
         ],
     ),
@@ -47,31 +47,31 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Numeric("9000000000000000000000000000000000000"),
+                value: Numeric(Some("9000000000000000000000000000000000000")),
             ),
             (
                 name: "yes_preference",
-                value: Numeric("91000000000000000000000000000000000000"),
+                value: Numeric(Some("91000000000000000000000000000000000000")),
             ),
             (
                 name: "total_auction_quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "winning_token",
-                value: Numeric("13"),
+                value: Numeric(Some("13")),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Numeric("15"),
+                value: Numeric(Some("15")),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Numeric("14"),
+                value: Numeric(Some("14")),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Numeric("13"),
+                value: Numeric(Some("13")),
             ),
             (
                 name: "market_close",
@@ -109,15 +109,15 @@
             ),
             (
                 name: "total_token",
-                value: Numeric("91000000000000000000000000000000000000"),
+                value: Numeric(Some("91000000000000000000000000000000000000")),
             ),
             (
                 name: "quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "rate",
-                value: Numeric("910000000000000000"),
+                value: Numeric(Some("910000000000000000")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132388-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132388-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    227,
-                ])),
+                value: Int(227),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    15,
-                ])),
+                value: Numeric("15"),
             ),
         ],
     ),
@@ -43,9 +39,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    227,
-                ])),
+                value: Int(227),
             ),
             (
                 name: "idx_string_0",
@@ -53,53 +47,31 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Int((1, [
-                    0,
-                    1302894480,
-                    1511079875,
-                    113595970,
-                ])),
+                value: Numeric("9000000000000000000000000000000000000"),
             ),
             (
                 name: "yes_preference",
-                value: Int((1, [
-                    0,
-                    3152120496,
-                    7701686,
-                    1148581478,
-                ])),
+                value: Numeric("91000000000000000000000000000000000000"),
             ),
             (
                 name: "total_auction_quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "winning_token",
-                value: Int((1, [
-                    13,
-                ])),
+                value: Numeric("13"),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Int((1, [
-                    15,
-                ])),
+                value: Numeric("15"),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Int((1, [
-                    14,
-                ])),
+                value: Numeric("14"),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Int((1, [
-                    13,
-                ])),
+                value: Numeric("13"),
             ),
             (
                 name: "market_close",
@@ -115,7 +87,7 @@
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -129,37 +101,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    227,
-                ])),
+                value: Int(227),
             ),
             (
                 name: "idx_address_1",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "total_token",
-                value: Int((1, [
-                    0,
-                    3152120496,
-                    7701686,
-                    1148581478,
-                ])),
+                value: Numeric("91000000000000000000000000000000000000"),
             ),
             (
                 name: "quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "rate",
-                value: Int((1, [
-                    3113943040,
-                    211875885,
-                ])),
+                value: Numeric("910000000000000000"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132390-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132390-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("15"),
+                value: Numeric(Some("15")),
             ),
         ],
     ),
@@ -43,11 +43,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("15"),
+                value: Numeric(Some("15")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("9890109890109890109"),
+                value: Numeric(Some("9890109890109890109")),
             ),
         ],
     ),
@@ -65,7 +65,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("15"),
+                value: Numeric(Some("15")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -73,7 +73,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -91,7 +91,7 @@
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Numeric("13"),
+                value: Numeric(Some("13")),
             ),
             (
                 name: "idx_tokens_address_2",
@@ -99,7 +99,7 @@
             ),
             (
                 name: "tokens_balance",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132390-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-132390-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    236,
-                ])),
+                value: Int(236),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    15,
-                ])),
+                value: Numeric("15"),
             ),
         ],
     ),
@@ -43,22 +39,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    236,
-                ])),
+                value: Int(236),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    15,
-                ])),
+                value: Numeric("15"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((1, [
-                    2241060413,
-                    2302720651,
-                ])),
+                value: Numeric("9890109890109890109"),
             ),
         ],
     ),
@@ -72,23 +61,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    236,
-                ])),
+                value: Int(236),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    15,
-                ])),
+                value: Numeric("15"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -102,23 +87,19 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    236,
-                ])),
+                value: Int(236),
             ),
             (
                 name: "idx_tokens_nat_3",
-                value: Int((1, [
-                    13,
-                ])),
+                value: Numeric("13"),
             ),
             (
                 name: "idx_tokens_address_2",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "tokens_balance",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-135501-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-135501-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    248,
-                ])),
+                value: Int(248),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    18,
-                ])),
+                value: Numeric("18"),
             ),
         ],
     ),
@@ -43,19 +39,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    248,
-                ])),
+                value: Int(248),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    18,
-                ])),
+                value: Numeric("18"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -69,19 +61,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    248,
-                ])),
+                value: Int(248),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    17,
-                ])),
+                value: Numeric("17"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -95,19 +83,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    248,
-                ])),
+                value: Int(248),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    16,
-                ])),
+                value: Numeric("16"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -121,9 +105,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    248,
-                ])),
+                value: Int(248),
             ),
             (
                 name: "idx_string_0",
@@ -131,47 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Int((1, [
-                    0,
-                    3458380512,
-                    3305005871,
-                    176704842,
-                ])),
+                value: Numeric("14000000000000000000000000000000000000"),
             ),
             (
                 name: "yes_preference",
-                value: Int((1, [
-                    0,
-                    996634464,
-                    2508742986,
-                    1085472605,
-                ])),
+                value: Numeric("86000000000000000000000000000000000000"),
             ),
             (
                 name: "total_auction_quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Int((1, [
-                    18,
-                ])),
+                value: Numeric("18"),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Int((1, [
-                    17,
-                ])),
+                value: Numeric("17"),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Int((1, [
-                    16,
-                ])),
+                value: Numeric("16"),
             ),
             (
                 name: "market_close",
@@ -187,7 +149,7 @@
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -201,37 +163,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    248,
-                ])),
+                value: Int(248),
             ),
             (
                 name: "idx_address_1",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "total_token",
-                value: Int((1, [
-                    0,
-                    996634464,
-                    2508742986,
-                    1085472605,
-                ])),
+                value: Numeric("86000000000000000000000000000000000000"),
             ),
             (
                 name: "quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "rate",
-                value: Int((1, [
-                    2329280512,
-                    200234353,
-                ])),
+                value: Numeric("860000000000000000"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-135501-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-135501-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("18"),
+                value: Numeric(Some("18")),
             ),
         ],
     ),
@@ -43,11 +43,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("18"),
+                value: Numeric(Some("18")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -65,11 +65,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("17"),
+                value: Numeric(Some("17")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -87,11 +87,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("16"),
+                value: Numeric(Some("16")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -113,27 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Numeric("14000000000000000000000000000000000000"),
+                value: Numeric(Some("14000000000000000000000000000000000000")),
             ),
             (
                 name: "yes_preference",
-                value: Numeric("86000000000000000000000000000000000000"),
+                value: Numeric(Some("86000000000000000000000000000000000000")),
             ),
             (
                 name: "total_auction_quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Numeric("18"),
+                value: Numeric(Some("18")),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Numeric("17"),
+                value: Numeric(Some("17")),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Numeric("16"),
+                value: Numeric(Some("16")),
             ),
             (
                 name: "market_close",
@@ -171,15 +171,15 @@
             ),
             (
                 name: "total_token",
-                value: Numeric("86000000000000000000000000000000000000"),
+                value: Numeric(Some("86000000000000000000000000000000000000")),
             ),
             (
                 name: "quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "rate",
-                value: Numeric("860000000000000000"),
+                value: Numeric(Some("860000000000000000")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-138208-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-138208-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    260,
-                ])),
+                value: Int(260),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    24,
-                ])),
+                value: Numeric("24"),
             ),
         ],
     ),
@@ -43,19 +39,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    260,
-                ])),
+                value: Int(260),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    24,
-                ])),
+                value: Numeric("24"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -69,19 +61,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    260,
-                ])),
+                value: Int(260),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    23,
-                ])),
+                value: Numeric("23"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -95,19 +83,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    260,
-                ])),
+                value: Int(260),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    22,
-                ])),
+                value: Numeric("22"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -121,9 +105,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    260,
-                ])),
+                value: Int(260),
             ),
             (
                 name: "idx_string_0",
@@ -131,47 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Int((1, [
-                    0,
-                    2589784192,
-                    3729275053,
-                    100974195,
-                ])),
+                value: Numeric("8000000000000000000000000000000000000"),
             ),
             (
                 name: "yes_preference",
-                value: Int((1, [
-                    0,
-                    1865230784,
-                    2084473804,
-                    1161203252,
-                ])),
+                value: Numeric("92000000000000000000000000000000000000"),
             ),
             (
                 name: "total_auction_quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Int((1, [
-                    24,
-                ])),
+                value: Numeric("24"),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Int((1, [
-                    23,
-                ])),
+                value: Numeric("23"),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Int((1, [
-                    22,
-                ])),
+                value: Numeric("22"),
             ),
             (
                 name: "market_close",
@@ -187,7 +149,7 @@
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -201,37 +163,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    260,
-                ])),
+                value: Int(260),
             ),
             (
                 name: "idx_address_1",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "total_token",
-                value: Int((1, [
-                    0,
-                    1865230784,
-                    2084473804,
-                    1161203252,
-                ])),
+                value: Numeric("92000000000000000000000000000000000000"),
             ),
             (
                 name: "quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "rate",
-                value: Int((1, [
-                    693895168,
-                    214204192,
-                ])),
+                value: Numeric("920000000000000000"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-138208-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-138208-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("24"),
+                value: Numeric(Some("24")),
             ),
         ],
     ),
@@ -43,11 +43,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("24"),
+                value: Numeric(Some("24")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -65,11 +65,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("23"),
+                value: Numeric(Some("23")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -87,11 +87,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("22"),
+                value: Numeric(Some("22")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -113,27 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Numeric("8000000000000000000000000000000000000"),
+                value: Numeric(Some("8000000000000000000000000000000000000")),
             ),
             (
                 name: "yes_preference",
-                value: Numeric("92000000000000000000000000000000000000"),
+                value: Numeric(Some("92000000000000000000000000000000000000")),
             ),
             (
                 name: "total_auction_quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Numeric("24"),
+                value: Numeric(Some("24")),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Numeric("23"),
+                value: Numeric(Some("23")),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Numeric("22"),
+                value: Numeric(Some("22")),
             ),
             (
                 name: "market_close",
@@ -171,15 +171,15 @@
             ),
             (
                 name: "total_token",
-                value: Numeric("92000000000000000000000000000000000000"),
+                value: Numeric(Some("92000000000000000000000000000000000000")),
             ),
             (
                 name: "quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "rate",
-                value: Numeric("920000000000000000"),
+                value: Numeric(Some("920000000000000000")),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-149127-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-149127-inserts.json
@@ -9,9 +9,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    272,
-                ])),
+                value: Int(272),
             ),
             (
                 name: "deleted",
@@ -19,17 +17,15 @@
             ),
             (
                 name: "stablecoin",
-                value: Address("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
+                value: String("KT1E8C3nQdPcUqmoU2MK9oCCsSiqThhaaJvm"),
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "last_token_created",
-                value: Int((1, [
-                    27,
-                ])),
+                value: Numeric("27"),
             ),
         ],
     ),
@@ -43,19 +39,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    272,
-                ])),
+                value: Int(272),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    27,
-                ])),
+                value: Numeric("27"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -69,19 +61,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    272,
-                ])),
+                value: Int(272),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    26,
-                ])),
+                value: Numeric("26"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -95,19 +83,15 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    272,
-                ])),
+                value: Int(272),
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Int((1, [
-                    25,
-                ])),
+                value: Numeric("25"),
             ),
             (
                 name: "tokens_nat_11",
-                value: Int((0, [])),
+                value: Numeric("0"),
             ),
         ],
     ),
@@ -121,9 +105,7 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    272,
-                ])),
+                value: Int(272),
             ),
             (
                 name: "idx_string_0",
@@ -131,47 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Int((1, [
-                    0,
-                    80023840,
-                    759390781,
-                    631088724,
-                ])),
+                value: Numeric("50000000000000000000000000000000000000"),
             ),
             (
                 name: "yes_preference",
-                value: Int((1, [
-                    0,
-                    80023840,
-                    759390781,
-                    631088724,
-                ])),
+                value: Numeric("50000000000000000000000000000000000000"),
             ),
             (
                 name: "total_auction_quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Int((1, [
-                    27,
-                ])),
+                value: Numeric("27"),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Int((1, [
-                    26,
-                ])),
+                value: Numeric("26"),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Int((1, [
-                    25,
-                ])),
+                value: Numeric("25"),
             ),
             (
                 name: "market_close",
@@ -187,7 +149,7 @@
             ),
             (
                 name: "owner",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
         ],
     ),
@@ -201,37 +163,23 @@
         columns: [
             (
                 name: "tx_context_id",
-                value: Int((1, [
-                    272,
-                ])),
+                value: Int(272),
             ),
             (
                 name: "idx_address_1",
-                value: Address("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
+                value: String("tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"),
             ),
             (
                 name: "total_token",
-                value: Int((1, [
-                    0,
-                    80023840,
-                    759390781,
-                    631088724,
-                ])),
+                value: Numeric("50000000000000000000000000000000000000"),
             ),
             (
                 name: "quantity",
-                value: Int((1, [
-                    1661992960,
-                    1808227885,
-                    5,
-                ])),
+                value: Numeric("100000000000000000000"),
             ),
             (
                 name: "rate",
-                value: Int((1, [
-                    3551657984,
-                    116415321,
-                ])),
+                value: Numeric("500000000000000000"),
             ),
         ],
     ),

--- a/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-149127-inserts.json
+++ b/test/KT1U7Adyu5A7JWvEVSKjJEkG2He2SU1nATfq-149127-inserts.json
@@ -25,7 +25,7 @@
             ),
             (
                 name: "last_token_created",
-                value: Numeric("27"),
+                value: Numeric(Some("27")),
             ),
         ],
     ),
@@ -43,11 +43,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("27"),
+                value: Numeric(Some("27")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -65,11 +65,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("26"),
+                value: Numeric(Some("26")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -87,11 +87,11 @@
             ),
             (
                 name: "idx_tokens_nat_10",
-                value: Numeric("25"),
+                value: Numeric(Some("25")),
             ),
             (
                 name: "tokens_nat_11",
-                value: Numeric("0"),
+                value: Numeric(Some("0")),
             ),
         ],
     ),
@@ -113,27 +113,27 @@
             ),
             (
                 name: "uniswap_contribution_factor",
-                value: Numeric("50000000000000000000000000000000000000"),
+                value: Numeric(Some("50000000000000000000000000000000000000")),
             ),
             (
                 name: "yes_preference",
-                value: Numeric("50000000000000000000000000000000000000"),
+                value: Numeric(Some("50000000000000000000000000000000000000")),
             ),
             (
                 name: "total_auction_quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "tokens_lqt_token_id",
-                value: Numeric("27"),
+                value: Numeric(Some("27")),
             ),
             (
                 name: "tokens_no_token_id",
-                value: Numeric("26"),
+                value: Numeric(Some("26")),
             ),
             (
                 name: "tokens_yes_token_id",
-                value: Numeric("25"),
+                value: Numeric(Some("25")),
             ),
             (
                 name: "market_close",
@@ -171,15 +171,15 @@
             ),
             (
                 name: "total_token",
-                value: Numeric("50000000000000000000000000000000000000"),
+                value: Numeric(Some("50000000000000000000000000000000000000")),
             ),
             (
                 name: "quantity",
-                value: Numeric("100000000000000000000"),
+                value: Numeric(Some("100000000000000000000")),
             ),
             (
                 name: "rate",
-                value: Numeric("500000000000000000"),
+                value: Numeric(Some("500000000000000000")),
             ),
         ],
     ),


### PR DESCRIPTION
# What

Insert values into postgres using binded variables, to reduce the sql injection attack surface.

And, refactoring of db related actions (mostly separation into more specific modules).

Protection against SQL injection through contract storage types is still a TODO. We shouldn't care about that anyways until we start running an indexer on _all_ contracts (if ever).

Specifics:
- moved database related operations out of the sql generation module into a separate module (db.rs)
- moved insert related operations out of the table module into a dedicated insert.rs module
- created a Sql related Values enum. we now process parser::Value and turn that into Columns that have insert::Value values.
- added "BEGIN; ... COMMIT;" to the schema generation, this way either the whole schema is generated (if no bug), or no schema at all is generated (in this way it is more clear in my opinion that something has gone wrong)
