### PR TITLE
Multiple contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .githooks
 *.swp
 rusty-tags.vi
+**/#*#

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /target
-contract.sql
 node_modules
 .env
 .githooks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,6 +783,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
@@ -1500,6 +1512,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad104641f3c958dab30eb3010e834c2622d1f3f4c530fef1dee20ad9485f3c09"
+dependencies = [
+ "dtoa",
+ "indexmap",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,6 +1628,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_yaml",
  "spinners",
  "termion",
 ]
@@ -2065,4 +2090,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 pretty_assertions = "*"
 
 [dependencies]
+serde_yaml = "0.8.20"
 backoff = "0.3.0"
 reqwest = { version = "0.11.4", features = ["blocking"] }
 flume = "0.10.8"

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ export DATABASE_URL=host=0.0.0.0 dbname=tezos user=quepasa password=quepasa port
 
 # PMM on GRANADA testnet:
 
-export NODE_URL=https://testnet-tezos.giganode.io
-export CONTRACT_ID=KT1B5Jg8unLXy2kvLGDEfvbcca3hQ29d8WhF
-NETWORK="granadanet"
+#export NODE_URL=https://testnet-tezos.giganode.io
+#export CONTRACT_ID=KT1B5Jg8unLXy2kvLGDEfvbcca3hQ29d8WhF
+#NETWORK="granadanet"
 
 # old PMM contract:
 #export CONTRACT_ID=KT18sHKbZtXhXtnf6ZrHEW9VgEe2eCvRr2CS
@@ -14,9 +14,9 @@ NETWORK="granadanet"
 
 # HEN on GRANADA:
 
-# export NODE_URL=https://mainnet-tezos.giganode.io
-# export CONTRACT_ID=KT1QxLqukyfohPV5kPkw97Rs6cw1DDDvYgbB
-# NETWORK="mainnet"
+export NODE_URL=https://mainnet-tezos.giganode.io
+export CONTRACT_ID=KT1QxLqukyfohPV5kPkw97Rs6cw1DDDvYgbB
+NETWORK="mainnet"
 
 
 gen-sql:

--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,6 @@ NETWORK="granadanet"
 # NETWORK="mainnet"
 
 
-gen-sql:
-ifeq ($(strip $(CONTRACT_ID)),"")
-	$(error variable CONTRACT_ID not set)
-else
-	RUST_BACKTRACE=1 cargo +nightly run -- generate-sql > contract.sql/init.sql
-endif
-
 start-db:
 	docker-compose up -d
 
@@ -54,5 +47,4 @@ else
 endif
 
 db:
-	make gen-sql
 	make start-db

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ export DATABASE_URL=host=0.0.0.0 dbname=tezos user=quepasa password=quepasa port
 
 # PMM on GRANADA testnet:
 
-#export NODE_URL=https://testnet-tezos.giganode.io
-#export CONTRACT_ID=KT1B5Jg8unLXy2kvLGDEfvbcca3hQ29d8WhF
-#NETWORK="granadanet"
+export NODE_URL=https://testnet-tezos.giganode.io
+export CONTRACT_ID=KT1B5Jg8unLXy2kvLGDEfvbcca3hQ29d8WhF
+NETWORK="granadanet"
 
 # old PMM contract:
 #export CONTRACT_ID=KT18sHKbZtXhXtnf6ZrHEW9VgEe2eCvRr2CS
@@ -14,9 +14,9 @@ export DATABASE_URL=host=0.0.0.0 dbname=tezos user=quepasa password=quepasa port
 
 # HEN on GRANADA:
 
-export NODE_URL=https://mainnet-tezos.giganode.io
-export CONTRACT_ID=KT1QxLqukyfohPV5kPkw97Rs6cw1DDDvYgbB
-NETWORK="mainnet"
+# export NODE_URL=https://mainnet-tezos.giganode.io
+# export CONTRACT_ID=KT1QxLqukyfohPV5kPkw97Rs6cw1DDDvYgbB
+# NETWORK="mainnet"
 
 
 gen-sql:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 export DATABASE_URL=host=0.0.0.0 dbname=tezos user=quepasa password=quepasa port=5432
+export CONTRACT_SETTINGS=settings.yaml
 # BLOCKS=245893,245894
 
 

--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,13 @@ export CONTRACT_SETTINGS=settings.yaml
 # BLOCKS=245893,245894
 
 
-# PMM on GRANADA testnet:
-
+# GRANADA testnet:
 export NODE_URL=https://testnet-tezos.giganode.io
-export CONTRACT_ID=KT1B5Jg8unLXy2kvLGDEfvbcca3hQ29d8WhF
 NETWORK="granadanet"
 
-# old PMM contract:
-#export CONTRACT_ID=KT18sHKbZtXhXtnf6ZrHEW9VgEe2eCvRr2CS
-
-
 # HEN on GRANADA:
-
-# export NODE_URL=https://mainnet-tezos.giganode.io
-# export CONTRACT_ID=KT1QxLqukyfohPV5kPkw97Rs6cw1DDDvYgbB
-# NETWORK="mainnet"
+#export NODE_URL=https://mainnet-tezos.giganode.io
+#NETWORK="mainnet"
 
 
 start-db:

--- a/contract.sql/.gitignore
+++ b/contract.sql/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/contract.sql/.gitignore
+++ b/contract.sql/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,5 +1,12 @@
+# PMM (on granada testnet)
 contracts:
-- name: "new"
+- name: "pmm_new"
   address: "KT1B5Jg8unLXy2kvLGDEfvbcca3hQ29d8WhF"
-- name: "old"
+- name: "pmm_old"
   address: "KT18sHKbZtXhXtnf6ZrHEW9VgEe2eCvRr2CS"
+
+
+# HEN
+contracts:
+- name: "hen_dao"
+  address: "KT1QxLqukyfohPV5kPkw97Rs6cw1DDDvYgbB"

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,0 +1,5 @@
+contracts:
+- name: "new"
+  address: "KT1B5Jg8unLXy2kvLGDEfvbcca3hQ29d8WhF"
+- name: "old"
+  address: "KT18sHKbZtXhXtnf6ZrHEW9VgEe2eCvRr2CS"

--- a/sql/postgresql-common-tables.sql
+++ b/sql/postgresql-common-tables.sql
@@ -41,3 +41,5 @@ CREATE UNIQUE INDEX ON tx_contexts(
     operation_number,
     content_number,
     coalesce(internal_number, -1));
+
+CREATE SCHEMA {contract_schema};

--- a/sql/postgresql-common-tables.sql
+++ b/sql/postgresql-common-tables.sql
@@ -7,7 +7,7 @@ CREATE UNIQUE INDEX levels__level ON levels(_level);
 CREATE UNIQUE INDEX levels_hash ON levels(hash);
 
 CREATE TABLE contract_levels (
-    contract VARCHAR(100) NOT NULL,
+    contract TEXT NOT NULL,
     level INTEGER NOT NULL,
     is_origination BOOLEAN NOT NULL DEFAULT false,
     PRIMARY KEY(contract, level)
@@ -22,7 +22,7 @@ INSERT INTO max_id (max_id) VALUES (1);
 CREATE TABLE tx_contexts(
        id INTEGER NOT NULL PRIMARY KEY,
        level INTEGER NOT NULL REFERENCES levels(_level) ON DELETE CASCADE,
-       contract VARCHAR(100) NOT NULL,
+       contract TEXT NOT NULL,
        operation_hash VARCHAR(100) NOT NULL,
        operation_group_number INTEGER NOT NULL,
        operation_number INTEGER NOT NULL,

--- a/sql/postgresql-common-tables.sql
+++ b/sql/postgresql-common-tables.sql
@@ -41,5 +41,3 @@ CREATE UNIQUE INDEX ON tx_contexts(
     operation_number,
     content_number,
     coalesce(internal_number, -1));
-
-CREATE SCHEMA {contract_schema};

--- a/sql/postgresql-common-tables.sql
+++ b/sql/postgresql-common-tables.sql
@@ -1,13 +1,17 @@
 CREATE TABLE levels (
-        id SERIAL PRIMARY KEY,
-        _level INTEGER NOT NULL,
-        is_origination BOOLEAN DEFAULT FALSE,
+        _level INTEGER PRIMARY KEY,
         hash VARCHAR(60),
         baked_at TIMESTAMP WITH TIME ZONE);
 
-
 CREATE UNIQUE INDEX levels__level ON levels(_level);
 CREATE UNIQUE INDEX levels_hash ON levels(hash);
+
+CREATE TABLE contract_levels (
+    contract VARCHAR(100) NOT NULL,
+    level INTEGER NOT NULL,
+    is_origination BOOLEAN NOT NULL DEFAULT false,
+    PRIMARY KEY(contract, level)
+);
 
 CREATE TABLE max_id (
        max_id INT4
@@ -18,6 +22,7 @@ INSERT INTO max_id (max_id) VALUES (1);
 CREATE TABLE tx_contexts(
        id INTEGER NOT NULL PRIMARY KEY,
        level INTEGER NOT NULL REFERENCES levels(_level) ON DELETE CASCADE,
+       contract VARCHAR(100) NOT NULL,
        operation_hash VARCHAR(100) NOT NULL,
        operation_group_number INTEGER NOT NULL,
        operation_number INTEGER NOT NULL,
@@ -27,8 +32,10 @@ CREATE TABLE tx_contexts(
        destination VARCHAR(100),
        entrypoint VARCHAR(100));
 
+
 CREATE UNIQUE INDEX ON tx_contexts(
     level,
+    contract,
     operation_hash,
     operation_group_number,
     operation_number,

--- a/sql/postgresql-table-header.sql
+++ b/sql/postgresql-table-header.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "{contract_schema}.{table}" (
+CREATE TABLE {contract_schema}."{table}" (
         id SERIAL PRIMARY KEY,
         deleted BOOLEAN DEFAULT false,
         tx_context_id INTEGER NOT NULL,

--- a/sql/postgresql-table-header.sql
+++ b/sql/postgresql-table-header.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "{}" (
+CREATE TABLE "{contract_schema}.{table}" (
         id SERIAL PRIMARY KEY,
         deleted BOOLEAN DEFAULT false,
         tx_context_id INTEGER NOT NULL,

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use clap::{App, Arg, SubCommand};
 
 #[derive(Clone, Default, Debug)]
 pub struct Config {
-    pub contract_id: String,
+    pub contract_id: ContractID,
     pub database_url: String,
     pub ssl: bool,
     pub ca_cert: Option<String>,
@@ -14,6 +14,12 @@ pub struct Config {
     pub network: String,
     pub bcd_url: Option<String>,
     pub workers_cap: usize,
+}
+
+#[derive(Hash, Eq, PartialEq, Clone, Default, Debug)]
+pub struct ContractID {
+    pub address: String,
+    pub name: String,
 }
 
 lazy_static! {
@@ -110,10 +116,15 @@ pub fn init_config() -> Result<Config> {
         )
         .get_matches();
 
-    config.contract_id = matches
+    let contract_address = matches
         .value_of("contract_id")
         .map_or_else(|| std::env::var("CONTRACT_ID"), |s| Ok(s.to_string()))
         .unwrap();
+
+    config.contract_id = ContractID {
+        address: contract_address,
+        name: "KT1B5Jg8unLXy2kvLGDEfvbcca3hQ29d8WhF".to_string(),
+    };
 
     config.generate_sql = match matches.subcommand() {
         ("generate-sql", _) => true,

--- a/src/highlevel.rs
+++ b/src/highlevel.rs
@@ -430,7 +430,8 @@ fn test_generate() {
         build_relational_ast(&context.clone(), &type_ast, &mut Indexes::new())
             .unwrap();
     println!("{:#?}", rel_ast);
-    let generator = crate::postgresql_generator::PostgresqlGenerator::new();
+    let generator =
+        crate::postgresql_generator::PostgresqlGenerator::new("testcontract");
     let mut builder = crate::sql::table_builder::TableBuilder::new();
     builder.populate(&rel_ast);
     let mut sorted_tables: Vec<_> = builder.tables.iter().collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,10 +69,10 @@ fn main() {
     // init by grabbing the contract data.
     info!(
         "getting the storage definition for contract={}..",
-        contract_id
+        contract_id.name
     );
     let storage_def = &node_cli
-        .get_contract_storage_definition(contract_id, None)
+        .get_contract_storage_definition(&contract_id.address, None)
         .unwrap();
     let type_ast = typing::storage_ast_from_json(storage_def)
         .with_context(|| {
@@ -152,7 +152,7 @@ fn main() {
                 let bcd_cli = bcd::BCDClient::new(
                     bcd_url,
                     CONFIG.network.clone(),
-                    contract_id.clone(),
+                    contract_id.address.clone(),
                 );
 
                 executor

--- a/src/sql/db.rs
+++ b/src/sql/db.rs
@@ -58,8 +58,8 @@ tx_contexts(id, level, contract, operation_group_number, operation_number, conte
                         .id
                         .ok_or_else(|| anyhow!("Missing ID on TxContext"))?
                         as i32),
-                    &tx_context.contract,
                     &(tx_context.level as i32),
+                    &tx_context.contract,
                     &(tx_context.operation_group_number as i32),
                     &(tx_context.operation_number as i32),
                     &(tx_context.content_number as i32),

--- a/src/sql/postgresql_generator.rs
+++ b/src/sql/postgresql_generator.rs
@@ -157,12 +157,8 @@ impl PostgresqlGenerator {
         })
     }
 
-    pub(crate) fn create_common_tables(&self) -> String {
-        format!(
-            include_str!("../../sql/postgresql-common-tables.sql"),
-            contract_schema = self.contract_id.name,
-        )
-        .to_string()
+    pub(crate) fn create_common_tables() -> String {
+        include_str!("../../sql/postgresql-common-tables.sql").to_string()
     }
 
     pub(crate) fn create_table_definition(

--- a/src/storage_value/processor.rs
+++ b/src/storage_value/processor.rs
@@ -143,8 +143,8 @@ impl StorageProcessor {
     pub(crate) fn process_block(
         &mut self,
         block: &block::Block,
-        rel_ast: &RelationalAST,
         contract_id: &str,
+        rel_ast: &RelationalAST,
     ) -> Result<(Inserts, Vec<TxContext>)> {
         self.inserts.clear();
         self.tx_contexts.clear();

--- a/src/storage_value/processor.rs
+++ b/src/storage_value/processor.rs
@@ -62,6 +62,7 @@ impl ProcessStorageContext {
 pub(crate) struct TxContext {
     pub id: Option<u32>,
     pub level: u32,
+    pub contract: String,
     pub operation_hash: String,
     pub operation_group_number: usize,
     pub operation_number: usize,
@@ -75,6 +76,7 @@ pub(crate) struct TxContext {
 impl Hash for TxContext {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.level.hash(state);
+        self.contract.hash(state);
         self.operation_hash.hash(state);
         self.operation_group_number.hash(state);
         self.operation_number.hash(state);
@@ -90,6 +92,7 @@ impl Hash for TxContext {
 impl PartialEq for TxContext {
     fn eq(&self, other: &Self) -> bool {
         self.level == other.level
+            && self.contract == other.contract
             && self.operation_hash == other.operation_hash
             && self.operation_group_number == other.operation_group_number
             && self.operation_number == other.operation_number
@@ -242,6 +245,7 @@ impl StorageProcessor {
                                     self.tx_context(TxContext {
                                         id: None,
                                         level,
+                                        contract: contract_id.to_string(),
                                         operation_hash: operation.hash.clone(),
                                         operation_number,
                                         operation_group_number,
@@ -279,6 +283,7 @@ impl StorageProcessor {
                                         self.tx_context(TxContext {
                                             id: None,
                                             level,
+                                            contract: contract_id.to_string(),
                                             operation_hash: operation
                                                 .hash
                                                 .clone(),
@@ -329,6 +334,7 @@ impl StorageProcessor {
                         let tx_context = TxContext {
                             id: None,
                             level,
+                            contract: contract_id.to_string(),
                             operation_hash: operation.hash.clone(),
                             operation_group_number,
                             operation_number,
@@ -363,6 +369,7 @@ impl StorageProcessor {
                             let tx_context = TxContext {
                                 id: None,
                                 level,
+                                contract: contract_id.to_string(),
                                 operation_hash: operation.hash.clone(),
                                 operation_group_number,
                                 operation_number,


### PR DESCRIPTION
# What

Add support for indexing more than 1 contract at once into the same database.

General approach: write each contract into its own postgres schema. keep global tables such as "levels" in the public schema.

Added nicknaming of contracts too + added a settings.yaml file for defining which contracts to run for (+ their nicknames).

Now, on every start, for all the new contracts added (if any) we do a bootstrap using better-call.dev if BCD has been enabled in the CLI args.

## Notes

- One of the tables that I have kept in public schema is "tx_contexts". Maybe it makes more sense to have this table in each contract's schema present instead (without the new "contract" column). I don't know right now.
- DB schema migration is now done inside rust. We're no longer printing it to STDOUT first and then sending it later into postgres.