### PR TITLE
Deep copy bigmap "copy" actions

### DIFF
--- a/sql/postgresql-common-tables.sql
+++ b/sql/postgresql-common-tables.sql
@@ -51,19 +51,24 @@ CREATE UNIQUE INDEX ON tx_contexts(
     content_number,
     coalesce(internal_number, -1));
 
-CREATE TABLE bigmap_deps(
-    tx_context_id BIGINT NOT NULL,
+CREATE TABLE contract_deps(
+    level INT NOT NULL,
 
     src_contract TEXT NOT NULL,
-    src_bigmap INTEGER NOT NULL,
-
     dest_schema TEXT NOT NULL,
-    dest_table TEXT NOT NULL,
-    dest_bigmap INTEGER NOT NULL,
 
-    FOREIGN KEY (tx_context_id) REFERENCES tx_contexts(id) ON DELETE CASCADE
+    PRIMARY KEY (level, src_contract, dest_schema)
 );
 
+CREATE TABLE bigmap_keys(
+    bigmap_id INTEGER NOT NULL,
+    tx_context_id BIGINT NOT NULL,
+    keyhash TEXT NOT NULL,
+    key TEXT NOT NULL,
+
+    PRIMARY KEY (bigmap_id, tx_context_id),
+    FOREIGN KEY (tx_context_id) REFERENCES tx_contexts(id) ON DELETE CASCADE
+);
 
 CREATE TABLE bigmap_copied_rows(
     src_contract TEXT NOT NULL,

--- a/sql/postgresql-common-tables.sql
+++ b/sql/postgresql-common-tables.sql
@@ -49,7 +49,7 @@ CREATE UNIQUE INDEX ON tx_contexts(
     operation_group_number,
     operation_number,
     content_number,
-    coalesce(internal_number, -1));
+    coalesce(internal_number, -2));
 
 CREATE TABLE contract_deps(
     level INT NOT NULL,
@@ -66,26 +66,6 @@ CREATE TABLE bigmap_keys(
     keyhash TEXT NOT NULL,
     key TEXT NOT NULL,
 
-    PRIMARY KEY (bigmap_id, tx_context_id),
+    PRIMARY KEY (bigmap_id, tx_context_id,keyhash),
     FOREIGN KEY (tx_context_id) REFERENCES tx_contexts(id) ON DELETE CASCADE
-);
-
-CREATE TABLE bigmap_copied_rows(
-    src_contract TEXT NOT NULL,
-
-    src_tx_context_id BIGINT NOT NULL,
-    dest_tx_context_id BIGINT NOT NULL,
-
-    dest_schema TEXT NOT NULL,
-    dest_table TEXT NOT NULL,
-    dest_row_id BIGINT NOT NULL,
-
-    FOREIGN KEY (src_tx_context_id) REFERENCES tx_contexts(id),
-    FOREIGN KEY (dest_tx_context_id) REFERENCES tx_contexts(id) ON DELETE CASCADE
-);
-
-CREATE TABLE bigmap_tables (
-    bigmap_id INTEGER PRIMARY KEY,
-    contract TEXT NOT NULL,
-    "table" TEXT NOT NULL
 );

--- a/sql/postgresql-snapshot-table-views.sql
+++ b/sql/postgresql-snapshot-table-views.sql
@@ -14,7 +14,7 @@ CREATE VIEW "{contract_schema}"."{table}_live" AS (
         ctx.operation_group_number DESC,
         ctx.operation_number DESC,
         ctx.content_number DESC,
-        COALESCE(ctx.internal_number, -1) DESC
+        COALESCE(ctx.internal_number, -2) DESC
     LIMIT 1
 );
 
@@ -26,7 +26,7 @@ CREATE VIEW "{contract_schema}"."{table}_ordered" AS (
                 ctx.operation_group_number,
                 ctx.operation_number,
                 ctx.content_number,
-                COALESCE(ctx.internal_number, -1)
+                COALESCE(ctx.internal_number, -2)
         ) AS ordering,
         ctx.level AS level,
         level_meta.baked_at AS level_timestamp,

--- a/src/highlevel.rs
+++ b/src/highlevel.rs
@@ -222,6 +222,9 @@ impl Executor {
         let mut levels = self
             .dbcli
             .get_dependent_levels(&config)?;
+        if levels.is_empty() {
+            return Ok(());
+        }
         levels.sort();
 
         info!("reprocessing following levels, they have bigmap copies whose keys are now fully known: {:?}", levels);

--- a/src/highlevel.rs
+++ b/src/highlevel.rs
@@ -914,13 +914,36 @@ fn test_block() {
         ) -> Result<JsonValue> {
             Err(anyhow!("dummy storage getter was not expected to be called in test_block tests"))
         }
+
+        fn get_bigmap_value(
+            &self,
+            _level: u32,
+            _bigmap_id: i32,
+            _keyhash: &str,
+        ) -> Result<Option<JsonValue>> {
+            Err(anyhow!("dummy storage getter was not expected to be called in test_block tests"))
+        }
+    }
+
+    struct DummyBigmapKeysGetter {}
+    impl crate::sql::db::BigmapKeysGetter for DummyBigmapKeysGetter {
+        fn get(
+            &mut self,
+            _level: u32,
+            _bigmap_id: i32,
+        ) -> Result<Vec<(String, String)>> {
+            Err(anyhow!("dummy bigmap keys getter was not expected to be called in test_block tests"))
+        }
     }
 
     let mut results: Vec<(&str, u32, Vec<Insert>)> = vec![];
     let mut expected: Vec<(&str, u32, Vec<Insert>)> = vec![];
     for contract in &contracts {
-        let mut storage_processor =
-            StorageProcessor::new(1, DummyStorageGetter {});
+        let mut storage_processor = StorageProcessor::new(
+            1,
+            DummyStorageGetter {},
+            DummyBigmapKeysGetter {},
+        );
 
         // verify that the test case is sane
         let mut unique_levels = contract.levels.clone();

--- a/src/highlevel.rs
+++ b/src/highlevel.rs
@@ -329,6 +329,7 @@ impl Executor {
                 latest_level,
             )?;
             if missing_levels.is_empty() {
+                self.exec_dependents()?;
                 return Ok(());
             }
 

--- a/src/highlevel.rs
+++ b/src/highlevel.rs
@@ -225,7 +225,7 @@ impl Executor {
         if levels.is_empty() {
             return Ok(());
         }
-        levels.sort();
+        levels.sort_unstable();
 
         info!("reprocessing following levels, they have bigmap copies whose keys are now fully known: {:?}", levels);
         self.exec_levels(1, levels)

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,6 +172,10 @@ fn main() {
                 executor
                     .exec_levels(num_getters, CONFIG.levels.clone())
                     .unwrap();
+            } else {
+                executor
+                    .exec_missing_levels(num_getters)
+                    .unwrap();
             }
         }
         if any_bootstrapped {
@@ -189,11 +193,13 @@ fn main() {
     }
 
     // We will first load missing levels (if any)
+    info!("processing missing levels");
     executor
         .exec_missing_levels(num_getters)
         .unwrap();
 
     // At last, normal operation.
+    info!("processing blocks at the chain head");
     executor.exec_continuous().unwrap();
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,86 +92,93 @@ fn main() {
         info!("Common tables set up in db");
     }
 
-    let deps = dbcli
-        .get_config_deps(&CONFIG.contracts)
-        .unwrap();
-
-    let mut executor = highlevel::Executor::new(node_cli.clone(), dbcli);
+    let mut executor = highlevel::Executor::new(
+        node_cli.clone(),
+        dbcli,
+        &CONFIG.database_url,
+        CONFIG.ssl,
+        CONFIG.ca_cert.clone(),
+    );
     let num_getters = CONFIG.workers_cap;
     if CONFIG.all_contracts {
         executor.index_all_contracts();
     } else {
-        let mut contracts: Vec<ContractID> = CONFIG.contracts.clone();
-        contracts.extend(
-            deps.into_iter()
-                .map(|addr| ContractID {
-                    name: addr.clone(),
-                    address: addr,
-                })
-                .collect::<Vec<ContractID>>(),
-        );
-        let contracts = contracts;
-        assert_contracts_ok(&contracts);
-        info!("running for contracts: {:#?}", contracts);
-
-        for contract_id in &contracts {
+        for contract_id in &CONFIG.contracts {
             executor
                 .add_contract(contract_id)
                 .unwrap();
         }
-        let new_contracts = executor
-            .create_contract_schemas()
-            .unwrap();
+        loop {
+            executor.add_dependency_contracts();
 
-        if CONFIG.recreate_views {
-            executor.recreate_views().unwrap();
-        }
+            let contracts = executor.get_config();
+            assert_contracts_ok(&contracts);
+            info!("running for contracts: {:#?}", contracts);
 
-        if !CONFIG.levels.is_empty() {
-            executor
-                .exec_levels(num_getters, CONFIG.levels.clone())
-                .unwrap();
-            return;
-        }
-
-        if let Some(bcd_url) = &CONFIG.bcd_url {
-            let mut exclude_levels: Vec<u32> = vec![];
-            for contract_id in &new_contracts {
-                info!("Initializing contract {}..", contract_id.name);
-                let bcd_cli = bcd::BCDClient::new(
-                    bcd_url.clone(),
-                    CONFIG.network.clone(),
-                    contract_id.address.clone(),
-                    &exclude_levels,
-                );
-
-                let processed_levels = executor
-                    .exec_parallel(num_getters, move |height_chan| {
-                        bcd_cli
-                            .populate_levels_chan(height_chan)
-                            .unwrap()
-                    })
-                    .unwrap();
-                exclude_levels.extend(processed_levels);
-
-                if let Some(l) =
-                    get_implicit_origination_level(&contract_id.address)
-                {
-                    executor.exec_level(l).unwrap();
-                }
-
-                executor
-                    .fill_in_levels(contract_id)
-                    .unwrap();
-
-                info!("contract {} initialized.", contract_id.name)
+            if CONFIG.recreate_views {
+                executor.recreate_views().unwrap();
             }
-        } else if !CONFIG.levels.is_empty() {
-            executor
-                .exec_levels(num_getters, CONFIG.levels.clone())
+
+            let new_contracts = executor
+                .create_contract_schemas()
                 .unwrap();
-            return;
+            if new_contracts.is_empty() {
+                break;
+            }
+
+            info!(
+                "initializing following contracts' historically: {:#?}",
+                new_contracts
+            );
+
+            if !CONFIG.levels.is_empty() {
+                executor
+                    .exec_levels(num_getters, CONFIG.levels.clone())
+                    .unwrap();
+                return;
+            }
+
+            if let Some(bcd_url) = &CONFIG.bcd_url {
+                let mut exclude_levels: Vec<u32> = vec![];
+                for contract_id in &new_contracts {
+                    info!("Initializing contract {}..", contract_id.name);
+                    let bcd_cli = bcd::BCDClient::new(
+                        bcd_url.clone(),
+                        CONFIG.network.clone(),
+                        contract_id.address.clone(),
+                        &exclude_levels,
+                    );
+
+                    let processed_levels = executor
+                        .exec_parallel(num_getters, move |height_chan| {
+                            bcd_cli
+                                .populate_levels_chan(height_chan)
+                                .unwrap()
+                        })
+                        .unwrap();
+                    exclude_levels.extend(processed_levels);
+
+                    if let Some(l) =
+                        get_implicit_origination_level(&contract_id.address)
+                    {
+                        executor.exec_level(l).unwrap();
+                    }
+
+                    executor
+                        .fill_in_levels(contract_id)
+                        .unwrap();
+
+                    info!("contract {} initialized.", contract_id.name)
+                }
+            } else if !CONFIG.levels.is_empty() {
+                executor
+                    .exec_levels(num_getters, CONFIG.levels.clone())
+                    .unwrap();
+            }
         }
+        executor.exec_dependents().unwrap();
+        info!("all contracts historically bootstrapped. restart to begin normal continuous processing mode.");
+        return;
     }
 
     // We will first load missing levels (if any)

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,7 @@ fn main() {
         executor
             .exec_levels(num_getters, CONFIG.levels.clone())
             .unwrap();
+        executor.exec_dependents().unwrap();
         return;
     }
 

--- a/src/octez/block.rs
+++ b/src/octez/block.rs
@@ -55,7 +55,7 @@ pub(crate) struct TxContext {
     pub operation_group_number: usize,
     pub operation_number: usize,
     pub content_number: usize,
-    pub internal_number: Option<usize>,
+    pub internal_number: Option<i32>,
     pub source: Option<String>,
     pub destination: Option<String>,
     pub entrypoint: Option<String>,
@@ -219,7 +219,7 @@ impl Block {
                                                     operation_number,
                                                     content_number,
                                                     internal_number: Some(
-                                                        internal_number,
+                                                        internal_number as i32,
                                                     ),
                                                     source: Some(
                                                         internal_op
@@ -258,7 +258,7 @@ impl Block {
                                                 operation_number,
                                                 content_number,
                                                 internal_number: Some(
-                                                    internal_number,
+                                                    internal_number as i32,
                                                 ),
                                                 source: Some(
                                                     internal_op.source.clone(),

--- a/src/octez/block.rs
+++ b/src/octez/block.rs
@@ -732,11 +732,10 @@ pub struct BigMapDiff {
     pub big_map: Option<String>,
     pub source_big_map: Option<String>,
     pub destination_big_map: Option<String>,
+    pub key_hash: Option<String>,
     pub key: Option<serde_json::Value>,
     pub value: Option<serde_json::Value>,
 
-    #[serde(skip)]
-    key_hash: Option<String>,
     #[serde(skip)]
     key_type: Option<KeyType>,
     #[serde(skip)]

--- a/src/octez/node.rs
+++ b/src/octez/node.rs
@@ -145,7 +145,7 @@ impl NodeClient {
     fn load_body(&self, endpoint: &str) -> Result<String> {
         let uri =
             format!("{}/chains/{}/{}", self.node_url, self.chain, endpoint);
-        println!("loading: {}", uri);
+        debug!("loading: {}", uri);
 
         let mut response = Vec::new();
         let mut handle = Easy::new();

--- a/src/octez/node.rs
+++ b/src/octez/node.rs
@@ -166,6 +166,13 @@ pub(crate) trait StorageGetter {
         contract_id: &str,
         level: u32,
     ) -> Result<JsonValue>;
+
+    fn get_bigmap_value(
+        &self,
+        level: u32,
+        bigmap_id: i32,
+        keyhash: &str,
+    ) -> Result<JsonValue>;
 }
 
 impl StorageGetter for NodeClient {
@@ -182,6 +189,24 @@ impl StorageGetter for NodeClient {
             format!(
                 "failed to get storage for contract='{}', level={}",
                 contract_id, level
+            )
+        })
+    }
+
+    fn get_bigmap_value(
+        &self,
+        level: u32,
+        bigmap_id: i32,
+        keyhash: &str,
+    ) -> Result<JsonValue> {
+        self.load(&format!(
+            "blocks/{}/context/big_map/{}/{}",
+            level, bigmap_id, keyhash,
+        ))
+        .with_context(|| {
+            format!(
+                "failed to get value for bigmap (level={}, bigmap_id={}, keyhash={})",
+                level, bigmap_id, keyhash,
             )
         })
     }

--- a/src/octez/node.rs
+++ b/src/octez/node.rs
@@ -128,7 +128,7 @@ impl NodeClient {
         let op = || -> Result<JsonValue> {
             let uri =
                 format!("{}/chains/{}/{}", self.node_url, self.chain, endpoint);
-            debug!("loading: {}", uri);
+            println!("loading: {}", uri);
 
             let mut response = Vec::new();
             let mut handle = Easy::new();
@@ -200,7 +200,7 @@ impl StorageGetter for NodeClient {
         keyhash: &str,
     ) -> Result<JsonValue> {
         self.load(&format!(
-            "blocks/{}/context/big_map/{}/{}",
+            "blocks/{}/context/big_maps/{}/{}",
             level, bigmap_id, keyhash,
         ))
         .with_context(|| {

--- a/src/sql/db.rs
+++ b/src/sql/db.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use native_tls::{Certificate, TlsConnector};
 use postgres::fallible_iterator::FallibleIterator;
-use postgres::row::Row;
 use postgres::types::{BorrowToSql, ToSql};
 use postgres::{Client, NoTls, Transaction};
 use postgres_native_tls::MakeTlsConnector;
@@ -20,7 +19,6 @@ use crate::sql::insert::{Column, Insert, Value};
 use crate::sql::postgresql_generator::PostgresqlGenerator;
 use crate::sql::table_builder::TableBuilder;
 use crate::storage_structure::relational::RelationalAST;
-use crate::storage_update::bigmap::BigmapCopy;
 
 pub struct DBClient {
     dbconn: postgres::Client,
@@ -267,6 +265,44 @@ WHERE table_schema = $1
             .collect())
     }
 
+    pub(crate) fn save_bigmap_keyhashes(
+        tx: &mut Transaction,
+        bigmap_keyhashes: Vec<(TxContext, i32, String, String)>,
+    ) -> Result<()> {
+        for chunk in bigmap_keyhashes.chunks(Self::INSERT_BATCH_SIZE) {
+            let num_columns = 4;
+            let v_refs = (1..(num_columns * chunk.len()) + 1)
+                .map(|i| format!("${}", i.to_string()))
+                .collect::<Vec<String>>()
+                .chunks(num_columns)
+                .map(|x| x.join(", "))
+                .join("), (");
+            let stmt = tx.prepare(&format!(
+                "
+INSERT INTO bigmap_keys (
+    tx_context_id, bigmap_id, keyhash, key
+)
+Values ({})",
+                v_refs
+            ))?;
+
+            let values: Vec<&dyn postgres::types::ToSql> = chunk
+                .iter()
+                .flat_map(|(tx_context, bigmap_id, keyhash, key)| {
+                    [
+                        tx_context.id.borrow_to_sql(),
+                        bigmap_id.borrow_to_sql(),
+                        keyhash.borrow_to_sql(),
+                        key.borrow_to_sql(),
+                    ]
+                })
+                .collect();
+
+            tx.query_raw(&stmt, values)?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn save_tx_contexts(
         tx: &mut Transaction,
         tx_contexts: &[TxContext],
@@ -353,185 +389,6 @@ tx_contexts(id, level, contract, operation_group_number, operation_number, conte
         Ok(())
     }
 
-    pub(crate) fn apply_bigmap_deps(
-        tx: &mut postgres::Transaction,
-        contract_id: &ContractID,
-        bigmap_deps: &[BigmapCopy],
-        next_id: &mut i64,
-    ) -> Result<()> {
-        for dep in bigmap_deps {
-            let ctx = format!("{}", dep.tx_context.id.unwrap());
-            let src_id = format!("{}", dep.src_bigmap);
-            let dest_id = format!("{}", dep.dest_bigmap);
-            tx.execute(
-                "
-INSERT INTO bigmap_deps(
-    tx_context_id, src_contract, src_bigmap, dest_schema, dest_table, dest_bigmap
-)
-SELECT
-    *
-FROM (
-    SELECT
-        x.ctx::integer as tx_context_id,
-        COALESCE(c.address, x.src_contract)::text as src_contract,
-        x.src_bigmap::integer,
-        x.dest_schema::text,
-        x.dest_table::text,
-        x.dest_bigmap::integer
-    FROM (VALUES ($1, $2, $3, $4, $5, $6)) x(ctx, src_contract, src_bigmap, dest_schema, dest_table, dest_bigmap)
-    LEFT JOIN contracts c
-      ON c.address = x.src_contract
-) q
-",
-                &[
-		    &ctx,
-                    &dep.src_contract,
-                    &src_id,
-                    &contract_id.name,
-		    &dep.dest_table,
-		    &dest_id,
-                ],
-            )?;
-
-            if let Some(src_schema) =
-                Self::get_contract_schema(tx, &dep.src_contract)?
-            {
-                if let Some(src_table) =
-                    Self::get_bigmap_table(tx, &src_schema, dep.src_bigmap)?
-                {
-                    let src_columns: Vec<String> =
-                        Self::get_table_columns(tx, &src_schema, &src_table)?
-                            .into_iter()
-                            .filter(|x| {
-                                x != "bigmap_id"
-                                    && x != "tx_context_id"
-                                    && x != "id"
-                            })
-                            .collect();
-
-                    let column_mapping = Self::get_tables_column_mapping(
-                        tx,
-                        &src_schema,
-                        &src_table,
-                        &contract_id.name,
-                        &dep.dest_table,
-                    )?;
-
-                    let dest_columns: Vec<String> = src_columns
-                        .iter()
-                        .map(|col| column_mapping[col].clone())
-                        .collect();
-
-                    let qry = format!(
-                        r#"
-WITH copy_rows AS (
-    SELECT
-        $1 + row_number() over ()::bigint as id,
-        src.tx_context_id,
-        {src_columns}
-    FROM "{src_schema}"."{src_table}" as src
-    JOIN tx_contexts ctx
-      ON ctx.id = src.tx_context_id
-    WHERE ctx.level < $2
-      AND src.bigmap_id = $3
-), insert_into_dest AS (
-    INSERT INTO "{dest_schema}"."{dest_table}" (
-        bigmap_id, tx_context_id, id, {dest_columns}
-    )
-    SELECT
-        $4,
-        $5,
-        src.id,
-        {src_columns}
-    FROM copy_rows as src
-)
-INSERT INTO bigmap_copied_rows (
-    src_tx_context_id, src_contract, dest_tx_context_id, dest_schema, dest_table, dest_row_id
-)
-SELECT
-    src.tx_context_id,
-    $6,
-    $5,
-    $7,
-    $8,
-    id
-FROM copy_rows src
-RETURNING dest_row_id"#,
-                        src_schema = src_schema,
-                        src_table = src_table,
-                        src_columns = src_columns
-                            .into_iter()
-                            .map(|col| format!(r#"src."{}""#, col))
-                            .join(", "),
-                        dest_schema = contract_id.name,
-                        dest_table = dep.dest_table,
-                        dest_columns = dest_columns.join(", "),
-                    );
-                    for row in tx.query(
-                        qry.as_str(),
-                        &[
-                            next_id,
-                            &(dep.tx_context.level as i32),
-                            &dep.src_bigmap,
-                            &dep.dest_bigmap,
-                            &dep.tx_context.id,
-                            &dep.src_contract,
-                            &contract_id.name,
-                            &dep.dest_table,
-                        ],
-                    )? {
-                        let inserted_id = row.get(0);
-                        if inserted_id > *next_id {
-                            *next_id = inserted_id;
-                        }
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn get_tables_column_mapping(
-        tx: &mut postgres::Transaction,
-        src_schema: &str,
-        src_table: &str,
-        dest_schema: &str,
-        dest_table: &str,
-    ) -> Result<HashMap<String, String>> {
-        let src_columns: Vec<String> =
-            Self::get_table_columns(tx, src_schema, src_table)?
-                .into_iter()
-                .collect();
-        let dest_columns: Vec<String> =
-            Self::get_table_columns(tx, dest_schema, dest_table)?
-                .into_iter()
-                .collect();
-        let mut res: HashMap<String, String> = HashMap::new();
-        for i in 0..src_columns.len() {
-            res.insert(src_columns[i].clone(), dest_columns[i].clone());
-        }
-        Ok(res)
-    }
-
-    pub(crate) fn save_bigmap_table_locations(
-        tx: &mut postgres::Transaction,
-        contract_id: &ContractID,
-        bigmap_locs: &[(i32, String)],
-    ) -> Result<()> {
-        for (bigmap_id, table) in bigmap_locs {
-            tx.execute(
-                r#"
-INSERT INTO bigmap_tables (
-    contract, "table", bigmap_id
-) VALUES ($1, $2, $3)
-ON CONFLICT DO NOTHING
-"#,
-                &[&contract_id.name, table, bigmap_id],
-            )?;
-        }
-        Ok(())
-    }
-
     pub(crate) fn apply_inserts(
         tx: &mut postgres::Transaction,
         level: i32,
@@ -567,196 +424,6 @@ ON CONFLICT DO NOTHING
                 Self::apply_inserts_for_table(tx, contract_id, chunk)?;
             }
         }
-        Self::populate_depending_bigmaps(
-            tx,
-            level,
-            contract_id,
-            inserts,
-            next_id,
-        )?;
-        Ok(())
-    }
-
-    pub(crate) fn populate_depending_bigmaps(
-        tx: &mut postgres::Transaction,
-        level: i32,
-        contract_id: &ContractID,
-        inserts: &[Insert],
-        next_id: &mut i64,
-    ) -> Result<()> {
-        let bigmap_inserts: Result<Vec<(i32, &Insert)>> = inserts
-            .iter()
-            .filter_map(|insert| {
-                insert
-                    .get_bigmap_id()
-                    .map(|res_id| res_id.map(|id| (id, insert)))
-            })
-            .collect();
-        let bigmap_inserts = bigmap_inserts?;
-        if bigmap_inserts.is_empty() {
-            return Ok(());
-        }
-
-        let mut bigmap_ids: HashMap<i32, ()> = HashMap::new();
-        for (bigmap_id, _) in &bigmap_inserts {
-            bigmap_ids.insert(*bigmap_id, ());
-        }
-
-        let bigmap_refs = (0..bigmap_ids.len())
-            .map(|i| format!("${}", (i + 3).to_string()))
-            .collect::<Vec<String>>()
-            .join(", ");
-
-        let mut args =
-            vec![contract_id.address.borrow_to_sql(), level.borrow_to_sql()];
-        args.extend::<Vec<&dyn ToSql>>(
-            bigmap_ids
-                .keys()
-                .map(|k| k.borrow_to_sql())
-                .collect(),
-        );
-
-        let mut rows: Vec<Row> = vec![];
-        {
-            let mut it = tx.query_raw(
-                format!(
-                    "
-SELECT
-    tx_context_id,
-    src_bigmap,
-    dest_schema,
-    dest_table,
-    dest_bigmap
-FROM bigmap_deps dep
-JOIN tx_contexts ctx
-  ON ctx.id = dep.tx_context_id
-WHERE src_contract = $1
-  AND ctx.level > $2
-  AND src_bigmap IN ({bigmap_refs})",
-                    bigmap_refs = bigmap_refs
-                )
-                .as_str(),
-                args,
-            )?;
-
-            while let Some(row) = it.next()? {
-                rows.push(row);
-            }
-        }
-        for row in rows {
-            let ctx_id_at_copy: i64 = row.get(0);
-            let src_bigmap: i32 = row.get(1);
-            let dest_schema: String = row.get(2);
-            let dest_table: String = row.get(3);
-            let dest_bigmap: i32 = row.get(4);
-
-            let mut dep_inserts: Vec<Insert> = vec![];
-
-            let mut ids: Vec<(i64, i64)> = vec![];
-            for (bigmap_id, insert) in &bigmap_inserts {
-                if *bigmap_id != src_bigmap {
-                    continue;
-                }
-
-                let src_tx_context_id = match insert.get_column("tx_context_id")
-                {
-                    Some(v) => match v.value {
-                        Value::BigInt(i) => Ok(i),
-                        _ => Err(anyhow!(
-                            "insert has bad tx_context_id value type"
-                        )),
-                    },
-                    None => Err(anyhow!("insert misses tx_context_id field")),
-                }?;
-                let column_mapping = Self::get_tables_column_mapping(
-                    tx,
-                    &contract_id.name,
-                    &insert.table_name,
-                    &dest_schema,
-                    &dest_table,
-                )?;
-
-                let mut dep_columns: Vec<Column> = vec![];
-                for insert in &insert.columns {
-                    if insert.name == "bigmap_id"
-                        || insert.name == "tx_context_id"
-                        || insert.name == "id"
-                    {
-                        continue;
-                    }
-                    dep_columns.push(Column {
-                        name: column_mapping[&insert.name].clone(),
-                        value: insert.value.clone(),
-                    });
-                }
-                let mut dep_insert = (*insert).clone();
-                *next_id += 1;
-                dep_insert.id = *next_id;
-                dep_insert.table_name = dest_table.clone();
-
-                dep_insert.columns = dep_columns;
-                dep_insert.columns.push(Column {
-                    name: "bigmap_id".to_string(),
-                    value: Value::Int(dest_bigmap),
-                });
-                dep_insert.columns.push(Column {
-                    name: "tx_context_id".to_string(),
-                    value: Value::BigInt(ctx_id_at_copy),
-                });
-
-                ids.push((dep_insert.id, src_tx_context_id));
-                dep_inserts.push(dep_insert);
-            }
-
-            Self::apply_inserts(
-                tx,
-                level,
-                &ContractID {
-                    name: dest_schema.clone(),
-                    address: "".to_string(),
-                },
-                &dep_inserts,
-                next_id,
-            )?;
-
-            let v_refs = (0..(ids.len() * 2))
-                .map(|i| format!("${}::bigint", (i + 5).to_string()))
-                .collect::<Vec<String>>()
-                .chunks(2)
-                .map(|x| x.join(", "))
-                .join("), (");
-            let mut args = vec![
-                contract_id.address.borrow_to_sql(),
-                ctx_id_at_copy.borrow_to_sql(),
-                dest_schema.borrow_to_sql(),
-                dest_table.borrow_to_sql(),
-            ];
-            for (id, src_tx_context_id) in &ids {
-                args.push(id.borrow_to_sql());
-                args.push(src_tx_context_id.borrow_to_sql());
-            }
-
-            let qry = format!(
-                r#"
-INSERT INTO bigmap_copied_rows (
-    src_contract, src_tx_context_id, dest_tx_context_id, dest_schema, dest_table, dest_row_id
-)
-SELECT
-    $1,
-    src_tx_context_id,
-    $2,
-    $3,
-    $4,
-    id
-FROM
-(
-    VALUES ({})
-) q(id, src_tx_context_id)
-"#,
-                v_refs
-            );
-            tx.query_raw(qry.as_str(), args)?;
-        }
         Ok(())
     }
 
@@ -777,7 +444,7 @@ FROM
                 "
 SELECT DISTINCT
     src_contract
-FROM bigmap_deps
+FROM contract_deps
 WHERE dest_schema IN ({})
 ",
                 v_refs
@@ -795,6 +462,45 @@ WHERE dest_schema IN ({})
         Ok(res
             .into_iter()
             .filter(|dep| !config.iter().any(|c| c.address == *dep))
+            .collect())
+    }
+
+    pub(crate) fn get_dependent_levels(
+        &mut self,
+        config: &[&ContractID],
+    ) -> Result<Vec<u32>> {
+        if config.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let v_refs = (0..config.len())
+            .map(|i| format!("${}", (i + 1).to_string()))
+            .collect::<Vec<String>>()
+            .join(", ");
+
+        let mut it = self.dbconn.query_raw(
+            format!(
+                "
+SELECT DISTINCT
+    level
+FROM contract_deps
+WHERE dest_schema IN ({})
+",
+                v_refs
+            )
+            .as_str(),
+            config
+                .iter()
+                .map(|c| c.name.borrow_to_sql())
+                .collect::<Vec<&dyn ToSql>>(),
+        )?;
+        let mut res: Vec<i32> = vec![];
+        while let Some(row) = it.next()? {
+            res.push(row.get(0));
+        }
+        Ok(res
+            .into_iter()
+            .map(|x| x as u32)
             .collect())
     }
 
@@ -894,7 +600,7 @@ WHERE table_schema = 'public'
         tx.simple_query(
             "
 DROP TABLE IF EXISTS bigmap_copied_rows;
-DROP TABLE IF EXISTS bigmap_deps;
+DROP TABLE IF EXISTS contract_deps;
 DROP TABLE IF EXISTS bigmap_tables;
 DROP TABLE IF EXISTS tx_contexts;
 DROP TABLE IF EXISTS max_id;
@@ -1144,6 +850,24 @@ WHERE contract = $1
         Ok(())
     }
 
+    pub(crate) fn save_contract_deps(
+        tx: &mut Transaction,
+        level: u32,
+        contract_id: &ContractID,
+        deps: Vec<String>,
+    ) -> Result<()> {
+        for dep in deps {
+            tx.execute(
+                "
+INSERT INTO contract_deps (tx_context_id, src, dest)
+VALUES ($1, $2, $3)
+ON CONFLICT DO NOTHING",
+                &[&(level as i32), &dep, &contract_id.name],
+            )?;
+        }
+        Ok(())
+    }
+
     /// get the origination of the contract, which is currently store in the levels (will change)
     pub(crate) fn set_origination(
         tx: &mut Transaction,
@@ -1190,5 +914,39 @@ WHERE contract = $1
         } else {
             Err(anyhow!("Too many results for get_origination"))
         }
+    }
+}
+
+pub(crate) trait BigmapKeysGetter {
+    fn get(
+        &mut self,
+        level: u32,
+        bigmap_id: i32,
+    ) -> Result<Vec<(String, String)>>;
+}
+
+impl BigmapKeysGetter for DBClient {
+    fn get(
+        &mut self,
+        level: u32,
+        bigmap_id: i32,
+    ) -> Result<Vec<(String, String)>> {
+        let res = self.dbconn.query(
+            "
+SELECT
+    keyhash,
+    key
+FROM bigmap_keys bigmap
+JOIN tx_contexts ctx
+  ON ctx.id = bigmap.tx_context_id
+WHERE bigmap_id = $1
+  AND ctx.level <= $2
+",
+            &[&bigmap_id, &(level as i32)],
+        )?;
+        Ok(res
+            .into_iter()
+            .map(|row| (row.get(0), row.get(1)))
+            .collect::<Vec<(String, String)>>())
     }
 }

--- a/src/sql/db.rs
+++ b/src/sql/db.rs
@@ -104,8 +104,6 @@ CREATE SCHEMA IF NOT EXISTS "{contract_schema}";
             )?;
 
             let noview_prefixes = builder.get_viewless_table_prefixes();
-            println!("remove from views: {:?}", noview_prefixes);
-
             for (_name, table) in sorted_tables {
                 let table_def = generator.create_table_definition(table)?;
                 tx.simple_query(table_def.as_str())?;
@@ -176,8 +174,6 @@ DROP VIEW "{contract_schema}"."{table}_live";
         sorted_tables.reverse();
 
         let noview_prefixes = builder.get_viewless_table_prefixes();
-        println!("remove from views: {:?}", noview_prefixes);
-
         for (_name, table) in sorted_tables {
             if !noview_prefixes
                 .iter()

--- a/src/sql/postgresql_generator.rs
+++ b/src/sql/postgresql_generator.rs
@@ -207,9 +207,6 @@ impl PostgresqlGenerator {
         &self,
         table: &Table,
     ) -> Result<String> {
-        if table.name == "bigmap_clears" {
-            return Ok("".to_string());
-        }
         if table.contains_snapshots() {
             self.create_views_for_snapshot_table(table)
         } else {

--- a/src/sql/table_builder.rs
+++ b/src/sql/table_builder.rs
@@ -24,6 +24,27 @@ impl TableBuilder {
         res
     }
 
+    pub(crate) fn get_viewless_table_prefixes(&self) -> Vec<String> {
+        let mut res: Vec<String> = vec!["bigmap_clears".to_string()];
+
+        // All child tables of changes tables cannot have view definitions defined.
+        // To get _ordered or _live rows for these child tables, simply join with id
+        // of parent bigmap table (on which there are _live and _ordered views defined).
+        res.extend(
+            self.tables
+                .values()
+                .filter_map(|t| {
+                    if t.contains_snapshots() {
+                        None
+                    } else {
+                        Some(format!("{}.", t.name))
+                    }
+                })
+                .collect::<Vec<String>>(),
+        );
+        res
+    }
+
     fn add_column(&mut self, is_keyword: bool, rel_entry: &RelationalEntry) {
         let mut table = self.get_table(&rel_entry.table_name);
         if rel_entry.is_index {

--- a/src/storage_update/bigmap.rs
+++ b/src/storage_update/bigmap.rs
@@ -122,6 +122,15 @@ impl IntraBlockBigmapDiffsProcessor {
             res.tx_bigmap_ops
                 .insert(tx_context, ops);
         }
+
+        if false {
+            let mut keys: Vec<&TxContext> = res.tx_bigmap_ops.keys().collect();
+            keys.sort();
+            for k in keys {
+                println!("tx[{:#?}]: {:#?}", k, res.tx_bigmap_ops[k]);
+            }
+        }
+
         res
     }
 
@@ -158,6 +167,7 @@ impl IntraBlockBigmapDiffsProcessor {
             if targets.is_empty() {
                 break;
             }
+
             for op in self.tx_bigmap_ops[tx_context]
                 .iter()
                 .rev()
@@ -261,7 +271,7 @@ fn test_normalizer() {
     fn op_update(bigmap: i32, ident: i32) -> Op {
         Op::Update {
             bigmap,
-            keyhash: "",
+            keyhash: "".to_string(),
             key: serde_json::Value::String(format!("{}", ident)),
             value: None,
         }

--- a/src/storage_update/processor.rs
+++ b/src/storage_update/processor.rs
@@ -231,19 +231,23 @@ where
         };
         let ctx = &self.tx_context(ctx);
 
+        let at_level = ctx.level - 1;
         for (keyhash, key) in self
             .bigmap_keys
-            .get(ctx.level, src_bigmap)?
+            .get(at_level, src_bigmap)?
         {
             let value = self
                 .node_cli
-                .get_bigmap_value(ctx.level, src_bigmap, &keyhash)?;
+                .get_bigmap_value(at_level, src_bigmap, &keyhash)?;
+            if value.is_none() {
+                continue;
+            }
 
             let op = bigmap::Op::Update {
                 bigmap: dest_bigmap,
-                keyhash: keyhash,
+                keyhash,
                 key: serde_json::from_str(&key)?,
-                value: serde_json::from_str(&value.to_string())?,
+                value: serde_json::from_str(&value.unwrap().to_string())?,
             };
             self.process_bigmap_op(&op, ctx)?;
         }

--- a/src/storage_update/processor.rs
+++ b/src/storage_update/processor.rs
@@ -2,14 +2,13 @@ use crate::debug;
 use crate::octez::block;
 use crate::octez::block::TxContext;
 use crate::octez::node::StorageGetter;
+use crate::sql::db::BigmapKeysGetter;
 use crate::sql::insert;
 use crate::sql::insert::{Column, Insert, InsertKey, Inserts};
 use crate::storage_structure::relational::{RelationalAST, RelationalEntry};
 use crate::storage_structure::typing::{ExprTy, SimpleExprTy};
 use crate::storage_update::bigmap;
-use crate::storage_update::bigmap::{
-    BigmapCopy, IntraBlockBigmapDiffsProcessor,
-};
+use crate::storage_update::bigmap::IntraBlockBigmapDiffsProcessor;
 use crate::storage_value::parser;
 use anyhow::{anyhow, Context, Result};
 use num::ToPrimitive;
@@ -91,29 +90,56 @@ impl IdGenerator {
 
 type BigMapMap = std::collections::HashMap<i32, (i64, RelationalAST)>;
 
-pub(crate) struct StorageProcessor<NodeCli>
+pub(crate) struct StorageProcessor<NodeCli, BigmapKeys>
 where
     NodeCli: StorageGetter,
+    BigmapKeys: BigmapKeysGetter,
 {
-    big_map_map: BigMapMap,
+    bigmap_map: BigMapMap,
+    bigmap_keyhashes: Vec<(TxContext, i32, String, String)>,
     id_generator: IdGenerator,
     inserts: Inserts,
     tx_contexts: TxContextMap,
     node_cli: NodeCli,
+    bigmap_keys: BigmapKeys,
 }
 
-impl<NodeCli> StorageProcessor<NodeCli>
+impl<NodeCli, BigmapKeys> StorageProcessor<NodeCli, BigmapKeys>
 where
     NodeCli: StorageGetter,
+    BigmapKeys: BigmapKeysGetter,
 {
-    pub(crate) fn new(initial_id: i64, node_cli: NodeCli) -> Self {
+    pub(crate) fn new(
+        initial_id: i64,
+        node_cli: NodeCli,
+        bigmap_keys: BigmapKeys,
+    ) -> Self {
         Self {
-            big_map_map: BigMapMap::new(),
+            bigmap_map: BigMapMap::new(),
             inserts: Inserts::new(),
             tx_contexts: HashMap::new(),
+            bigmap_keyhashes: Vec::new(),
             id_generator: IdGenerator::new(initial_id),
             node_cli,
+            bigmap_keys,
         }
+    }
+
+    fn add_bigmap_keyhash(
+        &mut self,
+        tx_context: TxContext,
+        bigmap: i32,
+        keyhash: String,
+        key: String,
+    ) {
+        self.bigmap_keyhashes
+            .push((tx_context, bigmap, keyhash, key));
+    }
+
+    pub(crate) fn get_bigmap_keyhashes(
+        &self,
+    ) -> Vec<(TxContext, i32, String, String)> {
+        self.bigmap_keyhashes.clone()
     }
 
     pub(crate) fn process_block(
@@ -122,10 +148,11 @@ where
         diffs: &IntraBlockBigmapDiffsProcessor,
         contract_id: &str,
         rel_ast: &RelationalAST,
-    ) -> Result<(Inserts, Vec<BigmapCopy>, Vec<TxContext>)> {
+    ) -> Result<(Inserts, Vec<TxContext>, Vec<String>)> {
         self.inserts.clear();
         self.tx_contexts.clear();
-        self.big_map_map.clear();
+        self.bigmap_map.clear();
+        self.bigmap_keyhashes.clear();
 
         let storages: Vec<(TxContext, parser::Value)> =
             block.map_tx_contexts(|tx_context, is_origination, op_res| {
@@ -148,13 +175,13 @@ where
                     )))
                 } else {
                     Err(anyhow!(
-			    "bad contract call: no storage update. tx_context={:#?}",
-			    tx_context
-			))
+                "bad contract call: no storage update. tx_context={:#?}",
+                tx_context
+            ))
                 }
             })?;
 
-        let mut bigmap_copies: Vec<BigmapCopy> = vec![];
+        let mut bigmap_contract_deps: HashMap<String, ()> = HashMap::new();
         for (tx_context, parsed_storage) in &storages {
             let tx_context = &self.tx_context(tx_context.clone());
             self.process_storage_value(parsed_storage, rel_ast, tx_context)
@@ -166,23 +193,19 @@ where
                 })?;
 
             let mut bigmaps = diffs.get_tx_context_owned_bigmaps(tx_context);
+
             bigmaps.sort_unstable();
             for bigmap in bigmaps {
                 let (deps, ops) = diffs.normalized_diffs(bigmap, tx_context);
-                if self.big_map_map.contains_key(&bigmap) {
-                    let (_fk, rel_ast) = &self.big_map_map[&bigmap];
+                if self.bigmap_map.contains_key(&bigmap) {
                     for (src_bigmap, src_context) in deps {
-                        let dest_bigmap = bigmap;
-                        let dest_table = rel_ast
-                            .table_entry()
-                            .ok_or_else(|| anyhow!("bigmap copy dest rel_ast has unexpected type"))?;
-                        bigmap_copies.push(BigmapCopy::new(
-                            tx_context.clone(),
-                            src_context.contract.clone(),
+                        bigmap_contract_deps
+                            .insert(src_context.contract.clone(), ());
+                        self.process_bigmap_copy(
+                            &src_context,
                             src_bigmap,
-                            dest_table,
-                            dest_bigmap,
-                        ));
+                            bigmap,
+                        );
                     }
                 }
                 for op in &ops {
@@ -193,18 +216,45 @@ where
 
         Ok((
             self.inserts.clone(),
-            bigmap_copies,
             self.tx_contexts
                 .keys()
                 .cloned()
                 .collect(),
+            bigmap_contract_deps
+                .into_keys()
+                .collect::<Vec<String>>(),
         ))
+    }
+
+    fn process_bigmap_copy(
+        &mut self,
+        ctx: &TxContext,
+        src_bigmap: i32,
+        dest_bigmap: i32,
+    ) -> Result<()> {
+        for (keyhash, key) in self
+            .bigmap_keys
+            .get(ctx.level, src_bigmap)?
+        {
+            let value = self
+                .node_cli
+                .get_bigmap_value(ctx.level, src_bigmap, &keyhash)?;
+
+            let op = bigmap::Op::Update {
+                bigmap: dest_bigmap,
+                keyhash: keyhash,
+                key: serde_json::from_str(&key)?,
+                value: serde_json::from_str(&value.to_string())?,
+            };
+            self.process_bigmap_op(&op, ctx)?;
+        }
+        Ok(())
     }
 
     pub(crate) fn get_bigmap_tables(&self) -> Result<Vec<(i32, String)>> {
         let mut res: Vec<(i32, String)> = vec![];
 
-        for (bigmap_id, (_fk, rel_ast)) in &self.big_map_map {
+        for (bigmap_id, (_fk, rel_ast)) in &self.bigmap_map {
             res.push((
                 *bigmap_id,
                 rel_ast
@@ -324,8 +374,13 @@ where
         tx_context: &TxContext,
     ) -> Result<()> {
         match op {
-            bigmap::Op::Update { bigmap, key, value } => {
-                let (_fk, rel_ast) = match self.big_map_map.get(bigmap) {
+            bigmap::Op::Update {
+                bigmap,
+                keyhash,
+                key,
+                value,
+            } => {
+                let (_fk, rel_ast) = match self.bigmap_map.get(bigmap) {
                     Some((fk, n)) => (fk, n.clone()),
                     None => {
                         return Ok(());
@@ -343,6 +398,13 @@ where
                         value_ast
                     },
                     {
+                        self.add_bigmap_keyhash(
+                            tx_context.clone(),
+                            *bigmap,
+                            keyhash.clone(),
+                            key.to_string(),
+                        );
+
                         let ctx = &ProcessStorageContext::new(
                             self.id_generator.get_id(),
                         )
@@ -777,7 +839,7 @@ where
         fk: i64,
         rel_ast: RelationalAST,
     ) {
-        self.big_map_map
+        self.bigmap_map
             .insert(bigmap_id, (fk, rel_ast));
     }
 


### PR DESCRIPTION
We failed to copy bigmap values correctly. Basically what we did was a shallow copy. But if a bigmap contains complex datatypes (ones that fold out into child tables), we'd fail to copy over child table's rows.

Changed the approach completely. Now we get the values from the node using keyhash and key info that we store in our db, this way we can simply reprocess the key,value pair in the context of the copied into bigmap.