### PR TITLE
Small docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ WORKDIR /que-pasa
 COPY --from=builder /usr/src/que-pasa/target/release/que-pasa ./
 
 RUN apt update
-RUN apt -y install libssl1.1 libcurl4
+RUN apt -y install libssl1.1 libcurl4 dumb-init
 
-ENTRYPOINT ["/que-pasa/que-pasa"]
+ENTRYPOINT ["/usr/bin/dumb-init", "/que-pasa/que-pasa"]

--- a/run_dockerized.sh
+++ b/run_dockerized.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
+ENV_FILE=env.example.sh
+echo "starting with env settings from file $ENV_FILE: `cat $ENV_FILE`"
 
-docker build -t que_pasa .
+docker build -t que_pasa . || exit 1
 
-env_file=$1
 docker run \
        --network host \
-       -e $env_file \
-       que_pasa \
-       que-pasa ${@:2}
+       -e $ENV_FILE \
+       que_pasa "$@"

--- a/run_dockerized.sh
+++ b/run_dockerized.sh
@@ -1,11 +1,6 @@
 #!/bin/sh
 
-ENV_FILE=env.example.sh
-echo "starting with env settings from file $ENV_FILE: `cat $ENV_FILE`"
-
-docker build -t que_pasa . || exit 1
-
 docker run \
        --network host \
-       -e $ENV_FILE \
-       que_pasa "$@"
+       ghcr.io/tzconnectberlin/que-pasa \
+       "$@"

--- a/script/publish-docker-image.bash
+++ b/script/publish-docker-image.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd $(git rev-parse --show-toplevel)
+
+docker build -t que-pasa . || exit 1
+docker push ghcr.io/tzconnectberlin/que-pasa:latest

--- a/script/publish-docker-image.bash
+++ b/script/publish-docker-image.bash
@@ -3,4 +3,5 @@
 cd $(git rev-parse --show-toplevel)
 
 docker build -t que-pasa . || exit 1
+docker tag que-pasa ghcr.io/tzconnectberlin/que-pasa:latest
 docker push ghcr.io/tzconnectberlin/que-pasa:latest

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@ pub struct ContractID {
 }
 
 lazy_static! {
-    pub static ref CONFIG: Config = init_config().unwrap();
+    pub static ref CONFIG: Result<Config> = init_config();
 }
 
 // init config and return it also.


### PR DESCRIPTION
# What

Reduced the runtime docker image size from 5G (!) to ~100MB. And added a script to publish it to our github hosted docker images repository, it's living under: `ghcr.io/tzconnectberlin/que-pasa` (with currently only the ":latest" tag).

Unrelated: removed the `.unwrap()` from the definition of one of the lazy refs. Because it's just not nice to have an `.unwrap()` fail even before `main()` has been reached..