### PR TITLE
Allow BCD for partially initialized contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "que-pasa"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "que-pasa"
-version = "1.0.6"
+version = "1.0.7"
 authors = ["Rick Klomp <rick.klomp@tzconnect.com>"]
 edition = "2018"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,7 +226,7 @@ fn schema_version(v: &str) -> String {
     v.to_string()
         .rsplit_once(".")
         .map(|(db_ver, _)| db_ver.to_string())
-        .unwrap_or("".to_string())
+        .unwrap_or_else(|| "".to_string())
 }
 
 fn assert_sane_db(dbcli: &mut DBClient) {

--- a/src/octez/bcd.rs
+++ b/src/octez/bcd.rs
@@ -1,4 +1,6 @@
 // bcd => better-call.dev
+use crate::config::ContractID;
+use crate::stats::StatsLogger;
 use anyhow::{anyhow, Result};
 use backoff::{retry, Error, ExponentialBackoff};
 use serde::Deserialize;
@@ -9,11 +11,15 @@ pub struct BCDClient {
     api_url: String,
     network: String,
     timeout: Duration,
-    contract_id: String,
+    contract_id: ContractID,
 }
 
 impl BCDClient {
-    pub fn new(api_url: String, network: String, contract_id: String) -> Self {
+    pub(crate) fn new(
+        api_url: String,
+        network: String,
+        contract_id: ContractID,
+    ) -> Self {
         Self {
             api_url,
             network,
@@ -22,8 +28,9 @@ impl BCDClient {
         }
     }
 
-    pub fn populate_levels_chan(
+    pub(crate) fn populate_levels_chan(
         &self,
+        stats: &StatsLogger,
         height_send: flume::Sender<u32>,
         exclude_levels: &[u32],
     ) -> Result<()> {
@@ -44,27 +51,34 @@ impl BCDClient {
         let latest_level = self.get_latest_level()?;
         send_level(latest_level)?;
 
+        let report_name =
+            &format!("better-call.dev '{}'", &self.contract_id.name);
+
         let mut last_id = None;
         loop {
             let (levels, new_last_id) = self.get_levels_page_with_contract(
-                self.contract_id.to_string(),
+                &self.contract_id.address,
                 last_id,
             )?;
             if levels.is_empty() {
                 break;
             }
-            last_id = Some(new_last_id);
 
             for level in levels {
                 send_level(level)?;
             }
+
+            stats.add(report_name, "pages", 1)?;
+            stats.set(report_name, "last_id", new_last_id.clone())?;
+
+            last_id = Some(new_last_id);
         }
         Ok(())
     }
 
     fn get_levels_page_with_contract(
         &self,
-        contract_id: String,
+        contract_addr: &str,
         last_id: Option<String>,
     ) -> Result<(Vec<u32>, String)> {
         let mut params = vec![("status".to_string(), "applied".to_string())];
@@ -83,7 +97,7 @@ impl BCDClient {
             pub last_id: String,
         }
         let parsed: Parsed = self.load(
-            format!("contract/{}/{}/operations", self.network, contract_id),
+            format!("contract/{}/{}/operations", self.network, contract_addr),
             &params,
             |resp| {
                 let parsed: Parsed = serde_json::from_str(resp)?;
@@ -134,6 +148,9 @@ impl BCDClient {
         F: Fn(&str) -> Result<O>,
     {
         fn transient_err(e: anyhow::Error) -> Error<anyhow::Error> {
+            //if e.is::<BadLevelHash>() {
+            //    let bad_lvl = e.downcast::<BadLevelHash>()?;
+            //}
             warn!("transient better-call.dev communication error, retrying.. err={}", e);
             Error::Transient(e)
         }

--- a/src/octez/bcd.rs
+++ b/src/octez/bcd.rs
@@ -148,9 +148,6 @@ impl BCDClient {
         F: Fn(&str) -> Result<O>,
     {
         fn transient_err(e: anyhow::Error) -> Error<anyhow::Error> {
-            //if e.is::<BadLevelHash>() {
-            //    let bad_lvl = e.downcast::<BadLevelHash>()?;
-            //}
             warn!("transient better-call.dev communication error, retrying.. err={}", e);
             Error::Transient(e)
         }

--- a/src/octez/node.rs
+++ b/src/octez/node.rs
@@ -114,7 +114,7 @@ impl NodeClient {
                     return Error::Permanent(downcast_err);
                 }
 
-                if curl_err.as_ref().ok().unwrap().code() == 28
+                match curl_err.as_ref().ok().unwrap().code() {
                     // 7: CONNECTION REFUSED
                     // 28: TIMEOUT
                     7 | 28 => {

--- a/src/octez/node.rs
+++ b/src/octez/node.rs
@@ -115,8 +115,8 @@ impl NodeClient {
                 }
 
                 match curl_err.as_ref().ok().unwrap().code() {
-                    // 0: OK, 28: TIMEOUT
-                    0 | 28 => {
+                    // 28: TIMEOUT
+                    28 => {
                         warn!("transient node communication error, retrying.. err={:?}", curl_err);
                         return Error::Transient(anyhow!("{:?}", curl_err));
                     }

--- a/src/octez/node.rs
+++ b/src/octez/node.rs
@@ -117,7 +117,8 @@ impl NodeClient {
                 match curl_err.as_ref().ok().unwrap().code() {
                     // 0: OK, 28: TIMEOUT
                     0 | 28 => {
-                        return Error::Transient(anyhow!("{:?}", curl_err))
+                        warn!("transient node communication error, retrying.. err={:?}", curl_err);
+                        return Error::Transient(anyhow!("{:?}", curl_err));
                     }
                     _ => {}
                 };
@@ -133,7 +134,7 @@ impl NodeClient {
                     curl_err_val.code(),
                 ));
             }
-            warn!("transient node communication error, retrying.. err={}", e);
+            warn!("transient node communication error, retrying.. err={:?}", e);
             Error::Transient(e)
         }
         let op = || -> Result<(String, serde_json::Value)> {

--- a/src/octez/node.rs
+++ b/src/octez/node.rs
@@ -114,11 +114,15 @@ impl NodeClient {
                     return Error::Permanent(downcast_err);
                 }
 
-                // 28: TIMEOUT
-                if curl_err.as_ref().ok().unwrap().code() == 28 {
-                    warn!("transient node communication error, retrying.. err={:?}", curl_err);
-                    return Error::Transient(anyhow!("{:?}", curl_err));
-                }
+                if curl_err.as_ref().ok().unwrap().code() == 28
+                    // 7: CONNECTION REFUSED
+                    // 28: TIMEOUT
+                    7 | 28 => {
+                        warn!("transient node communication error, retrying.. err={:?}", curl_err);
+                        return Error::Transient(anyhow!("{:?}", curl_err));
+                    }
+                    _ => {}
+                };
 
                 let curl_err_val = curl_err.ok().unwrap();
                 return Error::Permanent(anyhow!(

--- a/src/octez/node.rs
+++ b/src/octez/node.rs
@@ -118,12 +118,13 @@ impl NodeClient {
                 }
                 let curl_err_val = curl_err.ok().unwrap();
                 return Error::Permanent(anyhow!(
-                    "{} {}",
+                    "{} {} (curl status code: {})",
                     curl_err_val.description(),
                     curl_err_val
                         .extra_description()
                         .map(|descr| format!("(verbose: {})", descr))
                         .unwrap_or("".to_string()),
+                    curl_err_val.code(),
                 ));
             }
             warn!("transient node communication error, retrying.. err={}", e);

--- a/src/sql/db.rs
+++ b/src/sql/db.rs
@@ -968,6 +968,26 @@ set max_id = $1",
         }
     }
 
+    pub(crate) fn get_fully_processed_levels(&mut self) -> Result<Vec<u32>> {
+        let fully_processed: Vec<u32> = self
+            .dbconn
+            .query(
+                "
+SELECT
+    level
+FROM contract_levels
+GROUP by 1
+HAVING COUNT(1) = (SELECT COUNT(1) FROM contracts)
+ORDER by 1",
+                &[],
+            )?
+            .iter()
+            .map(|row| row.get(0))
+            .map(|lvl: i32| lvl as u32)
+            .collect();
+        Ok(fully_processed)
+    }
+
     pub(crate) fn get_partial_processed_levels(&mut self) -> Result<Vec<u32>> {
         let partial_processed: Vec<u32> = self
             .dbconn

--- a/src/sql/db.rs
+++ b/src/sql/db.rs
@@ -136,6 +136,7 @@ FROM indexer_state
         )?;
         Ok(())
     }
+
     pub(crate) fn common_tables_exist(&mut self) -> Result<bool> {
         let res = self.dbconn.query_opt(
             "

--- a/src/storage_structure/typing.rs
+++ b/src/storage_structure/typing.rs
@@ -98,7 +98,7 @@ pub(crate) fn storage_ast_from_json(json: &serde_json::Value) -> Result<Ele> {
             "address" => Ok(simple_expr!(SimpleExprTy::Address, annot)),
             "big_map" => Ok(complex_expr!(ComplexExprTy::BigMap, annot, args)),
             "bool" => Ok(simple_expr!(SimpleExprTy::Bool, annot)),
-            "bytes" => Ok(simple_expr!(SimpleExprTy::Bytes, annot)),
+            "bytes" | "chest" => Ok(simple_expr!(SimpleExprTy::Bytes, annot)),
             "int" => Ok(simple_expr!(SimpleExprTy::Int, annot)),
             "key" => Ok(simple_expr!(SimpleExprTy::KeyHash, annot)), // TODO: check this is correct
             "key_hash" => Ok(simple_expr!(SimpleExprTy::KeyHash, annot)),
@@ -178,7 +178,13 @@ pub(crate) fn storage_ast_from_json(json: &serde_json::Value) -> Result<Ele> {
             }
             "timestamp" => Ok(simple_expr!(SimpleExprTy::Timestamp, annot)),
             "unit" => Ok(simple_expr!(SimpleExprTy::Unit, annot)),
-            "never" | "ticket" | "sapling_state" | "lambda" => {
+            // - ignoring constants, as far as we can see now there's no reason
+            // to index these
+            // - ignoring tickets and sapling_state because it's not clear to
+            // us right now how this info would be used exactly
+            // - ignoring lambdas because they're a pandoras box. probably are
+            // impossible to index in a meaningful way
+            "constant" | "never" | "ticket" | "sapling_state" | "lambda" => {
                 Ok(simple_expr!(SimpleExprTy::Stop, annot))
             }
             "contract" | "signature" => {

--- a/src/storage_structure/typing.rs
+++ b/src/storage_structure/typing.rs
@@ -98,7 +98,14 @@ pub(crate) fn storage_ast_from_json(json: &serde_json::Value) -> Result<Ele> {
             "address" => Ok(simple_expr!(SimpleExprTy::Address, annot)),
             "big_map" => Ok(complex_expr!(ComplexExprTy::BigMap, annot, args)),
             "bool" => Ok(simple_expr!(SimpleExprTy::Bool, annot)),
-            "bytes" | "chest" => Ok(simple_expr!(SimpleExprTy::Bytes, annot)),
+            "bytes" | "chest" | "chest_key" => Ok(simple_expr!(
+                SimpleExprTy::Bytes,
+                annot.or_else(|| Some(
+                    prim.to_ascii_lowercase()
+                        .as_str()
+                        .to_string()
+                ))
+            )),
             "int" => Ok(simple_expr!(SimpleExprTy::Int, annot)),
             "key" => Ok(simple_expr!(SimpleExprTy::KeyHash, annot)), // TODO: check this is correct
             "key_hash" => Ok(simple_expr!(SimpleExprTy::KeyHash, annot)),

--- a/src/storage_structure/typing.rs
+++ b/src/storage_structure/typing.rs
@@ -173,7 +173,7 @@ pub(crate) fn storage_ast_from_json(json: &serde_json::Value) -> Result<Ele> {
                 })
             }
             "string" => Ok(simple_expr!(SimpleExprTy::String, annot)),
-            "bls12_381_g1" | "bls12_381_g2" | "bls12_381_fr" => {
+            "chain_id" | "bls12_381_g1" | "bls12_381_g2" | "bls12_381_fr" => {
                 Ok(simple_expr!(
                     SimpleExprTy::String,
                     annot.or_else(|| Some(

--- a/src/storage_update/bigmap.rs
+++ b/src/storage_update/bigmap.rs
@@ -52,7 +52,7 @@ impl Op {
             "update" => {
                 let updates: Vec<&Update> = match &raw.diff.updates {
                     Some(Update(u)) => vec![u],
-                    Some(Updates(us)) => us.iter().map(|u| u).collect(),
+                    Some(Updates(us)) => us.iter().collect(),
                     _ => {
                         return Err(anyhow!(
                             "unknown updates shape: {:#?}",


### PR DESCRIPTION
As addressed by this issue: https://github.com/tzConnectBerlin/que-pasa/issues/40, Que Pasa didn't allow to use BCD for faster bootstrapping when a contract had already been partially initialized in a previous Que Pasa invocation.

This PR moves the application of BCD to a more generic function `exec_missing_levels` that is always called on startup, and where this BCD was applied before now simply always calls `exec_missing_levels`. So we still have the same behavior as before for first initialization of new contracts.

Additionally this PR adds support for a few types that weren't supported yet:
- `chest` (stored as `text` in bytestring encodig in db)
- `chest_key` (stored as `text` in bytestring encodig in db)
- `chain_id` (stored as `text` in db)
- `constant` (is ignored. currently see no reason to index this)

And finally:
- Less greedy retry logic on node communication issues. Now it'll only retry on bad response data (non parsable, this seems to happen frequently when using a public node), timeouts, and connection refused
- Some improved logging of BCD application (printing some statistics to indicate progress, though it is not possible to know how much further we have to go without calling some additional metadata endpoint of BCD if they have this)