### PR TITLE
Variable global tables schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "que-pasa"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "que-pasa"
-version = "1.0.7"
+version = "1.1.0"
 authors = ["Rick Klomp <rick.klomp@tzconnect.com>"]
 edition = "2018"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM rust:1.54 AS builder
 
 WORKDIR /usr/src/que-pasa
-COPY src src
-COPY sql sql
-COPY *.yaml .
-COPY *.sh .
+COPY src src/
+COPY sql sql/
+COPY *.yaml ./
+COPY *.sh ./
 COPY Cargo.toml .
 COPY askama.toml .
 
@@ -18,6 +18,6 @@ WORKDIR /que-pasa
 COPY --from=builder /usr/src/que-pasa/target/release/que-pasa ./
 
 RUN apt update
-RUN apt -y install libssl1.1 libcurl4 dumb-init
+RUN apt -y install libssl1.1 libcurl4 dumb-init postgresql
 
 ENTRYPOINT ["/usr/bin/dumb-init", "/que-pasa/que-pasa"]

--- a/script/regression_tests.bash
+++ b/script/regression_tests.bash
@@ -1,6 +1,8 @@
 #!/bin/bash
 cd $(git rev-parse --show-toplevel)
 
+[ -z $DIFFTOOL ] && DIFFTOOL=kdiff3
+
 MODE=assert
 if [ $# -gt 0 ]; then
     MODE=$1
@@ -40,7 +42,7 @@ function query {
         tmp=`mktemp`
         echo "$exp" > $tmp
         if ! cmp $tmp $exp_file ; then
-            opendiff $tmp $exp_file
+            $DIFFTOOL $tmp $exp_file
             exit 1
         fi
     else
@@ -51,10 +53,10 @@ function query {
 
 function assert {
     query_id=0
-    query 'select count(1) from tx_contexts' || exit 1
-    query 'select count(1) from contracts' || exit 1
-    query 'select count(1) from contract_levels' || exit 1
-    query 'select count(1) from contract_deps' || exit 1
+    query 'select count(1) from que_pasa.tx_contexts' || exit 1
+    query 'select count(1) from que_pasa.contracts' || exit 1
+    query 'select count(1) from que_pasa.contract_levels' || exit 1
+    query 'select count(1) from que_pasa.contract_deps' || exit 1
 
     query 'select administrator, all_tokens, paused, level, level_timestamp from "KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton"."storage_live"' || exit 1
     query 'select level, level_timestamp, idx_address, idx_nat, nat from "KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton"."storage.ledger_live" order by idx_address, idx_nat' || exit 1

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,8 @@ use std::fs;
 
 #[derive(Clone, Default, Debug)]
 pub struct Config {
+    pub main_schema: String,
+
     pub contracts: Vec<ContractID>,
     pub all_contracts: bool,
     pub database_url: String,
@@ -43,6 +45,16 @@ pub fn init_config() -> Result<Config> {
         .version(QUEPASA_VERSION)
         .author("Rick Klomp <rick.klomp@tzconect.com>")
         .about("An indexer for specific contracts")
+        .arg(
+            Arg::with_name("main_schema")
+                .short("s")
+                .long("main-schema")
+                .value_name("MAIN_SCHEMA")
+                .env("MAIN_SCHEMA")
+                .default_value("que_pasa")
+                .help("schema to use for global tables (eg levels table)")
+                .takes_value(true)
+        )
         .arg(
             Arg::with_name("contract_settings")
                 .short("c")
@@ -172,6 +184,8 @@ pub fn init_config() -> Result<Config> {
                 .help("If set, never prompt for confirmations, always default to 'yes'")
                 .takes_value(false));
     let matches = matches.get_matches();
+
+    config.main_schema = matches.value_of("main_schema").unwrap().to_string();
 
     let maybe_fpath = matches.value_of("contract_settings");
     if let Some(fpath) = maybe_fpath {

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,8 +131,7 @@ Re-initializing -- all data in DB related to ever set-up contracts, including th
         )
         .unwrap();
     if !new_initialized.is_empty() {
-        info!("all contracts historically bootstrapped. restart to begin normal continuous processing mode.");
-        return;
+        info!("all contracts historically bootstrapped.");
     }
 
     info!("running for contracts: {:#?}", contracts);

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ fn main() {
         &node::NodeClient::new(config.node_url.clone(), "main".to_string());
 
     let mut dbcli = DBClient::connect(
+        &config.main_schema,
         &config.database_url,
         config.ssl,
         config.ca_cert.clone(),

--- a/test/regression/1.query
+++ b/test/regression/1.query
@@ -1,4 +1,4 @@
-select count(1) from tx_contexts;
+select count(1) from que_pasa.tx_contexts;
  count 
 -------
   1132

--- a/test/regression/2.query
+++ b/test/regression/2.query
@@ -1,4 +1,4 @@
-select count(1) from contracts;
+select count(1) from que_pasa.contracts;
  count 
 -------
    147

--- a/test/regression/3.query
+++ b/test/regression/3.query
@@ -1,4 +1,4 @@
-select count(1) from contract_levels;
+select count(1) from que_pasa.contract_levels;
  count 
 -------
    313

--- a/test/regression/4.query
+++ b/test/regression/4.query
@@ -1,4 +1,4 @@
-select count(1) from contract_deps;
+select count(1) from que_pasa.contract_deps;
  count 
 -------
      0


### PR DESCRIPTION
Allow global Que Pasa tables (such as "levels" table) to be placed in a different schema than the default schema (which is usually "public" schema).