### PR TITLE
before initial bootstrap with bcd, wait for node sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "que-pasa"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Rick Klomp <rick.klomp@tzconnect.com>"]
 edition = "2018"
 

--- a/run_dockerized.sh
+++ b/run_dockerized.sh
@@ -2,5 +2,5 @@
 
 docker run \
        --network host \
-       ghcr.io/tzconnectberlin/que-pasa:1.1.1 \
+       ghcr.io/tzconnectberlin/que-pasa:1.1.2 \
        "$@"

--- a/src/highlevel.rs
+++ b/src/highlevel.rs
@@ -396,10 +396,9 @@ impl Executor {
         loop {
             let latest_level: LevelMeta = self.node_cli.head()?;
 
-            let mut missing_levels: Vec<u32> = self.dbcli.get_missing_levels(
-                &self.get_config()?,
-                latest_level.level + 1,
-            )?;
+            let mut missing_levels: Vec<u32> = self
+                .dbcli
+                .get_missing_levels(&self.get_config()?, latest_level.level)?;
             if missing_levels.is_empty() {
                 break;
             }
@@ -436,6 +435,7 @@ impl Executor {
 
                     let excl = exclude_levels.clone();
                     let stats = self.stats.clone();
+                    let node_cli = self.node_cli.clone();
                     let processed_levels = self
                         .exec_parallel(
                             num_getters,
@@ -443,6 +443,7 @@ impl Executor {
                             move |height_chan| {
                                 bcd_cli
                                     .populate_levels_chan(
+                                        || Ok(node_cli.head()?.level),
                                         &stats,
                                         height_chan,
                                         &excl,
@@ -565,10 +566,9 @@ impl Executor {
 
         if ensure_sane_input_state {
             let latest_level: LevelMeta = self.node_cli.head()?;
-            let missing_levels: Vec<u32> = self.dbcli.get_missing_levels(
-                &self.get_config()?,
-                latest_level.level + 1,
-            )?;
+            let missing_levels: Vec<u32> = self
+                .dbcli
+                .get_missing_levels(&self.get_config()?, latest_level.level)?;
             let has_gaps = missing_levels
                 .windows(2)
                 .any(|w| w[0] != w[1] - 1);


### PR DESCRIPTION
2 fixes:

- Before initial bootstrap with better-call.dev enabled, we have to wait for our nodes to be in sync with better-call.dev's nodes. Otherwise the block fetch of the head will result in a `404`, crashing que pasa.
- Bugfix in the `exec_missing_levels`, misunderstood the semantics of postgres'  `generate_series` function. it's `to` argument is inclusive, i thought it was exclusive. This resulted in the level above head to be included in this list, and when trying to execute it'd then crash Que Pasa due to `404` on trying to fetch this block.