### PR TITLE
bugfix: we were still using big_map_diff in terms of control flow 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "que-pasa"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "que-pasa"
-version = "1.2.3"
+version = "1.2.4"
 authors = ["Rick Klomp <rick.klomp@tzconnect.com>"]
 edition = "2018"
 

--- a/run_dockerized.sh
+++ b/run_dockerized.sh
@@ -2,5 +2,5 @@
 
 docker run \
        --network host \
-       ghcr.io/tzconnectberlin/que-pasa:1.2.3 \
+       ghcr.io/tzconnectberlin/que-pasa:1.2.4 \
        "$@"

--- a/src/storage_update/bigmap.rs
+++ b/src/storage_update/bigmap.rs
@@ -187,21 +187,12 @@ impl IntraBlockBigmapDiffsProcessor {
         let tx_bigmap_ops = block.map_tx_contexts(
             |tx_context, _tx, _is_origination, op_res| {
                 let mut ops: Vec<Op> = vec![];
-                const FROM_LAZY: bool = true;
-                if FROM_LAZY && op_res.lazy_storage_diff.is_some() {
-                    for lazy_diff in op_res
-                        .lazy_storage_diff
-                        .as_ref()
-                        .unwrap()
-                    {
-                        ops.extend(Op::from_raw_lazy(lazy_diff)?);
-                    }
-                } else {
-                    for op in op_res.big_map_diff.as_ref().unwrap() {
-                        if let Some(op_parsed) = Op::from_raw(op)? {
-                            ops.push(op_parsed);
-                        }
-                    }
+                for lazy_diff in op_res
+                    .lazy_storage_diff
+                    .as_ref()
+                    .unwrap()
+                {
+                    ops.extend(Op::from_raw_lazy(lazy_diff)?);
                 }
                 Ok(Some((tx_context, ops)))
             },

--- a/src/storage_update/bigmap.rs
+++ b/src/storage_update/bigmap.rs
@@ -187,12 +187,24 @@ impl IntraBlockBigmapDiffsProcessor {
         let tx_bigmap_ops = block.map_tx_contexts(
             |tx_context, _tx, _is_origination, op_res| {
                 let mut ops: Vec<Op> = vec![];
-                for lazy_diff in op_res
-                    .lazy_storage_diff
-                    .as_ref()
-                    .unwrap()
-                {
-                    ops.extend(Op::from_raw_lazy(lazy_diff)?);
+                const FROM_LAZY: bool = true;
+                if FROM_LAZY && op_res.lazy_storage_diff.is_some() {
+                    for lazy_diff in op_res
+                        .lazy_storage_diff
+                        .as_ref()
+                        .unwrap()
+                    {
+                        ops.extend(Op::from_raw_lazy(lazy_diff)?);
+                    }
+                } else {
+                    if op_res.big_map_diff.is_none() {
+                        return Ok(Some((tx_context, vec![])));
+                    }
+                    for op in op_res.big_map_diff.as_ref().unwrap() {
+                        if let Some(op_parsed) = Op::from_raw(op)? {
+                            ops.push(op_parsed);
+                        }
+                    }
                 }
                 Ok(Some((tx_context, ops)))
             },

--- a/src/storage_update/bigmap.rs
+++ b/src/storage_update/bigmap.rs
@@ -186,28 +186,24 @@ impl IntraBlockBigmapDiffsProcessor {
 
         let tx_bigmap_ops = block.map_tx_contexts(
             |tx_context, _tx, _is_origination, op_res| {
-                if op_res.big_map_diff.is_none() {
-                    Ok(Some((tx_context, vec![])))
+                let mut ops: Vec<Op> = vec![];
+                const FROM_LAZY: bool = true;
+                if FROM_LAZY && op_res.lazy_storage_diff.is_some() {
+                    for lazy_diff in op_res
+                        .lazy_storage_diff
+                        .as_ref()
+                        .unwrap()
+                    {
+                        ops.extend(Op::from_raw_lazy(lazy_diff)?);
+                    }
                 } else {
-                    let mut ops: Vec<Op> = vec![];
-                    const FROM_LAZY: bool = true;
-                    if FROM_LAZY && op_res.lazy_storage_diff.is_some() {
-                        for lazy_diff in op_res
-                            .lazy_storage_diff
-                            .as_ref()
-                            .unwrap()
-                        {
-                            ops.extend(Op::from_raw_lazy(lazy_diff)?);
-                        }
-                    } else {
-                        for op in op_res.big_map_diff.as_ref().unwrap() {
-                            if let Some(op_parsed) = Op::from_raw(op)? {
-                                ops.push(op_parsed);
-                            }
+                    for op in op_res.big_map_diff.as_ref().unwrap() {
+                        if let Some(op_parsed) = Op::from_raw(op)? {
+                            ops.push(op_parsed);
                         }
                     }
-                    Ok(Some((tx_context, ops)))
                 }
+                Ok(Some((tx_context, ops)))
             },
         )?;
         for (tx_context, ops) in tx_bigmap_ops {


### PR DESCRIPTION
This field has been depracated for a long time now and with the most recent tezos upgrade (to jakarta) the Octez implementation stopped returning this field.

Relying on it was a bug (the whole removed "if" was unnecessary ever since we started processing lazy_storage_diffs).
