### PR TITLE
Bugfix: --main-schema feature was broken

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "que-pasa"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "que-pasa"
-version = "1.2.5"
+version = "1.2.6"
 authors = ["Rick Klomp <rick.klomp@tzconnect.com>"]
 edition = "2018"
 

--- a/run_dockerized.sh
+++ b/run_dockerized.sh
@@ -2,5 +2,5 @@
 
 docker run \
        --network host \
-       ghcr.io/tzconnectberlin/que-pasa:1.2.5 \
+       ghcr.io/tzconnectberlin/que-pasa:1.2.6 \
        "$@"

--- a/script/regression_tests.bash
+++ b/script/regression_tests.bash
@@ -53,10 +53,10 @@ function query {
 
 function assert {
     query_id=0
-    query 'select count(1) from que_pasa.tx_contexts' || exit 1
-    query 'select count(1) from que_pasa.contracts' || exit 1
-    query 'select count(1) from que_pasa.contract_levels' || exit 1
-    query 'select count(1) from que_pasa.contract_deps' || exit 1
+    query 'select count(1) from "custom_Main_Schema".tx_contexts' || exit 1
+    query 'select count(1) from "custom_Main_Schema".contracts' || exit 1
+    query 'select count(1) from "custom_Main_Schema".contract_levels' || exit 1
+    query 'select count(1) from "custom_Main_Schema".contract_deps' || exit 1
 
     query 'select administrator, all_tokens, paused, level, level_timestamp from "KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton"."storage_live"' || exit 1
     query 'select level, level_timestamp, idx_address, idx_nat, nat from "KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton"."storage.ledger_live" order by idx_address, idx_nat' || exit 1
@@ -118,15 +118,15 @@ EOF
 
 export RUST_BACKTRACE=1
 
-cargo run -- --index-all-contracts -l 1500000-1500001 || exit 1
-cargo run --features regression_force_update_derived -- --index-all-contracts -l 1500002-1500005 || exit 1
-cargo run --features regression_force_update_derived -- --index-all-contracts -l 1700002-1700005 || exit 1
+cargo run -- --main-schema custom_Main_Schema --index-all-contracts -l 1500000-1500001 || exit 1
+cargo run --features regression_force_update_derived -- --main-schema custom_Main_Schema --index-all-contracts -l 1500002-1500005 || exit 1
+cargo run --features regression_force_update_derived -- --main-schema custom_Main_Schema --index-all-contracts -l 1700002-1700005 || exit 1
 
 # the latter has a delete bigmap, the first 3 have rows indexed of the deleted bigmap
-cargo run --features regression_force_update_derived -- --index-all-contracts -l 1768431 || exit 1
-cargo run --features regression_force_update_derived -- --index-all-contracts -l 1768503 || exit 1
-cargo run --features regression_force_update_derived -- --index-all-contracts -l 1768506 || exit 1
-cargo run --features regression_force_update_derived -- --index-all-contracts -l 1768606 || exit 1
+cargo run --features regression_force_update_derived -- --main-schema custom_Main_Schema --index-all-contracts -l 1768431 || exit 1
+cargo run --features regression_force_update_derived --  --main-schema custom_Main_Schema --index-all-contracts -l 1768503 || exit 1
+cargo run --features regression_force_update_derived -- --main-schema custom_Main_Schema --index-all-contracts -l 1768506 || exit 1
+cargo run --features regression_force_update_derived -- --main-schema custom_Main_Schema --index-all-contracts -l 1768606 || exit 1
 
 if [[ "$MODE" == "inspect" ]]; then
     psql

--- a/sql/common-tables.sql
+++ b/sql/common-tables.sql
@@ -92,10 +92,10 @@ CREATE VIEW txs_ordered AS (
         ctx.level,
         meta.baked_at as level_timestamp,
         tx.*
-    FROM que_pasa.txs tx
-    JOIN que_pasa.tx_contexts ctx
+    FROM txs tx
+    JOIN tx_contexts ctx
       ON ctx.id = tx.tx_context_id
-    JOIN que_pasa.levels meta
+    JOIN levels meta
       ON meta.level = ctx.level
     ORDER BY ordering
 );
@@ -136,7 +136,7 @@ CREATE TABLE bigmap_keys(
 );
 
 
-CREATE OR REPLACE FUNCTION que_pasa.last_context_at(lvl INT) RETURNS TABLE (tx_context_id BIGINT, level INT, operation_group_number INT, operation_number INT, content_number INT, internal_number INT)
+CREATE OR REPLACE FUNCTION "{main_schema}".last_context_at(lvl INT) RETURNS TABLE (tx_context_id BIGINT, level INT, operation_group_number INT, operation_number INT, content_number INT, internal_number INT)
 AS $$
     SELECT
       ctx.id as tx_context_id,
@@ -145,17 +145,17 @@ AS $$
       operation_number,
       content_number,
       internal_number
-    FROM que_pasa.tx_contexts AS ctx
+    FROM "{main_schema}".tx_contexts AS ctx
     WHERE id = (
       SELECT id
-      FROM que_pasa.tx_contexts
+      FROM "{main_schema}".tx_contexts
       WHERE level <= lvl
       ORDER BY level DESC, operation_group_number DESC, operation_number DESC, content_number DESC, COALESCE(internal_number, -1) DESC
       LIMIT 1
     )
 $$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION que_pasa.last_context_at(lvl INT, op_grp INT) RETURNS TABLE (tx_context_id BIGINT, level INT, operation_group_number INT, operation_number INT, content_number INT, internal_number INT)
+CREATE OR REPLACE FUNCTION "{main_schema}".last_context_at(lvl INT, op_grp INT) RETURNS TABLE (tx_context_id BIGINT, level INT, operation_group_number INT, operation_number INT, content_number INT, internal_number INT)
 AS $$
     SELECT
       ctx.id AS tx_context_id,
@@ -164,10 +164,10 @@ AS $$
       operation_number,
       content_number,
       internal_number
-    FROM que_pasa.tx_contexts AS ctx
+    FROM "{main_schema}".tx_contexts AS ctx
     WHERE id = (
       SELECT id
-      FROM que_pasa.tx_contexts
+      FROM "{main_schema}".tx_contexts
       WHERE ARRAY[
             level,
             operation_group_number]
@@ -180,7 +180,7 @@ AS $$
     )
 $$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION que_pasa.last_context_at(lvl INT, op_grp INT, op INT) RETURNS TABLE (tx_context_id BIGINT, level INT, operation_group_number INT, operation_number INT, content_number INT, internal_number INT)
+CREATE OR REPLACE FUNCTION "{main_schema}".last_context_at(lvl INT, op_grp INT, op INT) RETURNS TABLE (tx_context_id BIGINT, level INT, operation_group_number INT, operation_number INT, content_number INT, internal_number INT)
 AS $$
     SELECT
       ctx.id,
@@ -189,10 +189,10 @@ AS $$
       operation_number,
       content_number,
       internal_number
-    FROM que_pasa.tx_contexts AS ctx
+    FROM "{main_schema}".tx_contexts AS ctx
     WHERE id = (
       SELECT id
-      FROM que_pasa.tx_contexts
+      FROM "{main_schema}".tx_contexts
       WHERE ARRAY[
             level,
             operation_group_number,
@@ -207,7 +207,7 @@ AS $$
     )
 $$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION que_pasa.last_context_at(lvl INT, op_grp INT, op INT, content INT) RETURNS TABLE (tx_context_id BIGINT, level INT, operation_group_number INT, operation_number INT, content_number INT, internal_number INT)
+CREATE OR REPLACE FUNCTION "{main_schema}".last_context_at(lvl INT, op_grp INT, op INT, content INT) RETURNS TABLE (tx_context_id BIGINT, level INT, operation_group_number INT, operation_number INT, content_number INT, internal_number INT)
 AS $$
     SELECT
       ctx.id AS tx_context_id,
@@ -216,10 +216,10 @@ AS $$
       operation_number,
       content_number,
       internal_number
-    FROM que_pasa.tx_contexts AS ctx
+    FROM "{main_schema}".tx_contexts AS ctx
     WHERE id = (
       SELECT id
-      FROM que_pasa.tx_contexts
+      FROM "{main_schema}".tx_contexts
       WHERE ARRAY[
             level,
             operation_group_number,
@@ -236,7 +236,7 @@ AS $$
     )
 $$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION que_pasa.last_context_at(lvl INT, op_grp INT, op INT, content INT, internal INT) RETURNS TABLE (tx_context_id BIGINT, level INT, operation_group_number INT, operation_number INT, content_number INT, internal_number INT)
+CREATE OR REPLACE FUNCTION "{main_schema}".last_context_at(lvl INT, op_grp INT, op INT, content INT, internal INT) RETURNS TABLE (tx_context_id BIGINT, level INT, operation_group_number INT, operation_number INT, content_number INT, internal_number INT)
 AS $$
     SELECT
       ctx.id AS tx_context_id,
@@ -245,10 +245,10 @@ AS $$
       operation_number,
       content_number,
       internal_number
-    FROM que_pasa.tx_contexts AS ctx
+    FROM "{main_schema}".tx_contexts AS ctx
     WHERE id = (
       SELECT id
-      FROM que_pasa.tx_contexts
+      FROM "{main_schema}".tx_contexts
       WHERE ARRAY[
             level,
             operation_group_number,

--- a/sql/templates/create-changes-functions.sql
+++ b/sql/templates/create-changes-functions.sql
@@ -17,8 +17,8 @@ AS $$
       , LAST_VALUE(t.{{ col }}) OVER w AS {{ col }}
     {%- endfor %}
     FROM "{{ contract_schema }}"."{{ table }}_ordered" AS t
-    CROSS JOIN que_pasa.contracts AS contract
-    JOIN que_pasa.tx_contexts ctx
+    CROSS JOIN "{{ main_schema }}".contracts AS contract
+    JOIN "{{ main_schema }}".tx_contexts ctx
       ON  ctx.id = t.tx_context_id
       AND ctx.contract = contract.address
     WHERE contract.name = '{{ contract_schema }}'

--- a/sql/templates/create-entrypoint-changes-functions.sql
+++ b/sql/templates/create-entrypoint-changes-functions.sql
@@ -28,16 +28,16 @@ BEGIN
         value->>'contract_address' AS address,
         value->>'table' AS "table"
       INTO source
-      FROM bigmap_meta_actions AS meta
+      FROM "{{ main_schema }}".bigmap_meta_actions AS meta
       WHERE action = 'alloc'
         AND meta.bigmap_id = (
           SELECT (value->'source')::INT
-          FROM bigmap_meta_actions AS meta
+          FROM "{{ main_schema }}".bigmap_meta_actions AS meta
           WHERE meta.action = 'copy'
             AND meta.bigmap_id = bigmap_target
             AND tx_context_id = (
               SELECT ctx.id
-              FROM tx_contexts AS ctx
+              FROM "{{ main_schema }}".tx_contexts AS ctx
               JOIN "{{ contract_schema }}"."{{ table }}" AS t
                 ON t.tx_context_id = ctx.id
               WHERE ARRAY[
@@ -60,7 +60,7 @@ BEGIN
 
       SELECT name
       INTO source_schema
-      FROM contracts
+      FROM "{{ main_schema }}".contracts
       WHERE address = source.address;
 
       in_schema := source_schema;

--- a/sql/templates/create-function-shortcuts.sql
+++ b/sql/templates/create-function-shortcuts.sql
@@ -13,7 +13,7 @@ AS $$
   FROM (
     SELECT
       "{{ contract_schema }}"."{{ table }}_{{ function_postfix }}"(ctx.level, ctx.operation_group_number, ctx.operation_number, ctx.content_number, ctx.internal_number)
-    FROM que_pasa.last_context_at(lvl) AS ctx
+    FROM "{{ main_schema }}".last_context_at(lvl) AS ctx
   ) q
 $$ LANGUAGE SQL;
 
@@ -21,19 +21,19 @@ CREATE OR REPLACE FUNCTION "{{ contract_schema }}"."{{ table }}_{{ function_post
 AS $$
   SELECT
     "{{ contract_schema }}"."{{ table }}_{{ function_postfix }}"(ctx.level, ctx.operation_group_number, ctx.operation_number, ctx.content_number, ctx.internal_number)
-  FROM que_pasa.last_context_at(lvl, op_grp) AS ctx
+  FROM "{{ main_schema }}".last_context_at(lvl, op_grp) AS ctx
 $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION "{{ contract_schema }}"."{{ table }}_{{ function_postfix }}"(lvl INT, op_grp INT, op INT) RETURNS TABLE ({% call unfold(typed_columns, "", false) %})
 AS $$
   SELECT
     "{{ contract_schema }}"."{{ table }}_{{ function_postfix }}"(ctx.level, ctx.operation_group_number, ctx.operation_number, ctx.content_number, ctx.internal_number)
-  FROM que_pasa.last_context_at(lvl, op_grp, op) AS ctx
+  FROM "{{ main_schema }}".last_context_at(lvl, op_grp, op) AS ctx
 $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION "{{ contract_schema }}"."{{ table }}_{{ function_postfix }}"(lvl INT, op_grp INT, op INT, content INT) RETURNS TABLE ({% call unfold(typed_columns, "", false) %})
 AS $$
   SELECT
     "{{ contract_schema }}"."{{ table }}_{{ function_postfix }}"(ctx.level, ctx.operation_group_number, ctx.operation_number, ctx.content_number, ctx.internal_number)
-  FROM que_pasa.last_context_at(lvl, op_grp, op, content) AS ctx
+  FROM "{{ main_schema }}".last_context_at(lvl, op_grp, op, content) AS ctx
 $$ LANGUAGE SQL;

--- a/sql/templates/create-snapshot-functions.sql
+++ b/sql/templates/create-snapshot-functions.sql
@@ -12,7 +12,7 @@ AS $$
     SELECT
       ctx.id AS tx_context_id
     FROM "{{ contract_schema }}"."{{ table }}" AS t
-    JOIN que_pasa.tx_contexts ctx
+    JOIN "{{ main_schema }}".tx_contexts ctx
       ON ctx.id = t.tx_context_id
     WHERE ARRAY[
           ctx.level,

--- a/sql/templates/repopulate-changes-derived.sql
+++ b/sql/templates/repopulate-changes-derived.sql
@@ -32,12 +32,12 @@ FROM (
             t.*
         FROM "{{ contract_schema }}"."{{ table }}" t
         WHERE t.bigmap_id NOT IN (
-            SELECT bigmap_id FROM que_pasa.bigmap_meta_actions WHERE action = 'clear'
+            SELECT bigmap_id FROM "{{ main_schema }}".bigmap_meta_actions WHERE action = 'clear'
         )
     ) t
-    JOIN tx_contexts ctx
+    JOIN "{{ main_schema }}".tx_contexts ctx
       ON ctx.id = t.tx_context_id
-    JOIN levels level_meta
+    JOIN "{{ main_schema }}".levels level_meta
       ON level_meta.level = ctx.level
     ORDER BY
         {% call unfold(indices, "t", false) %},
@@ -95,10 +95,10 @@ FROM (
               {%- for col in columns %}
                 , LAST_VALUE(t.{{ col }}) OVER w AS {{ col }}
               {%- endfor %}
-            FROM que_pasa.bigmap_meta_actions AS bigmap_meta
+            FROM "{{ main_schema }}".bigmap_meta_actions AS bigmap_meta
             JOIN "{{ contract_schema }}"."{{ table }}" t
               ON t.bigmap_id = bigmap_meta.bigmap_id
-            JOIN tx_contexts ctx
+            JOIN "{{ main_schema }}".tx_contexts ctx
               ON ctx.id = t.tx_context_id
             WHERE bigmap_meta.action = 'clear'
             WINDOW w AS (
@@ -120,9 +120,9 @@ FROM (
         WHERE NOT t.latest_deleted
           AND t2 IS NULL
     ) t  -- t with bigmap clears unfolded
-    JOIN tx_contexts ctx
+    JOIN "{{ main_schema }}".tx_contexts ctx
       ON ctx.id = t.tx_context_id
-    JOIN levels level_meta
+    JOIN "{{ main_schema }}".levels level_meta
       ON level_meta.level = ctx.level
 ) q;
 

--- a/sql/templates/repopulate-snapshot-derived.sql
+++ b/sql/templates/repopulate-snapshot-derived.sql
@@ -26,7 +26,7 @@ FROM (
         ctx.id,
         ctx.level
       FROM "{{ contract_schema }}"."{{ parent_table }}" t
-      JOIN tx_contexts ctx
+      JOIN "{{ main_schema }}".tx_contexts ctx
         ON ctx.id = t.tx_context_id
       ORDER BY
           ctx.level DESC,
@@ -36,7 +36,7 @@ FROM (
           COALESCE(ctx.internal_number, -1) DESC
       LIMIT 1
     ) last_ctx
-    JOIN levels level_meta
+    JOIN "{{ main_schema }}".levels level_meta
       ON level_meta.level = last_ctx.level
     WHERE t.tx_context_id = last_ctx.id
 ) q;
@@ -64,8 +64,8 @@ FROM (
         t.tx_context_id
         {% call unfold(columns, "t", true) %}
     FROM "{{ contract_schema }}"."{{ table }}" t
-    JOIN tx_contexts ctx
+    JOIN "{{ main_schema }}".tx_contexts ctx
       ON ctx.id = t.tx_context_id
-    JOIN levels level_meta
+    JOIN "{{ main_schema }}".levels level_meta
       ON level_meta.level = ctx.level
 ) q;

--- a/sql/templates/update-changes-derived.sql
+++ b/sql/templates/update-changes-derived.sql
@@ -12,7 +12,7 @@ DELETE FROM "{{ contract_schema }}"."{{ table }}_live"
 WHERE bigmap_id IN (
     SELECT
         bigmap_id
-    FROM que_pasa.bigmap_meta_actions
+    FROM "{{ main_schema }}".bigmap_meta_actions
     WHERE tx_context_id in ({% call unfold(tx_context_ids, "", false) %})
       AND action = 'clear'
 );
@@ -25,9 +25,9 @@ WHERE id IN (
         SELECT DISTINCT
             {% call unfold(indices, "t", false) %}
         FROM "{{ contract_schema }}"."{{ table }}" t
-        JOIN tx_contexts ctx
+        JOIN "{{ main_schema }}".tx_contexts ctx
           ON ctx.id = t.tx_context_id
-        JOIN levels level_meta
+        JOIN "{{ main_schema }}".levels level_meta
           ON level_meta.level = ctx.level
         WHERE t.tx_context_id IN ({% call unfold(tx_context_ids, "", false) %})
     ) as overwritten_indices
@@ -55,9 +55,9 @@ FROM (
         level_meta.baked_at AS level_timestamp,
         t.*
     FROM "{{ contract_schema }}"."{{ table }}" t
-    JOIN tx_contexts ctx
+    JOIN "{{ main_schema }}".tx_contexts ctx
       ON ctx.id = t.tx_context_id
-    JOIN levels level_meta
+    JOIN "{{ main_schema }}".levels level_meta
       ON level_meta.level = ctx.level
     WHERE t.tx_context_id IN ({% call unfold(tx_context_ids, "", false) %})
     ORDER BY
@@ -122,10 +122,10 @@ FROM (
               {%- for col in columns %}
                 , LAST_VALUE(t.{{ col }}) OVER w as {{ col }}
               {%- endfor %}
-            FROM que_pasa.bigmap_meta_actions bigmap_meta
+            FROM "{{ main_schema }}".bigmap_meta_actions bigmap_meta
             JOIN "{{ contract_schema }}"."{{ table }}" t
               ON t.bigmap_id = bigmap_meta.bigmap_id
-            JOIN tx_contexts ctx
+            JOIN "{{ main_schema }}".tx_contexts ctx
               ON ctx.id = t.tx_context_id
             WHERE bigmap_meta.tx_context_id IN ({% call unfold(tx_context_ids, "", false) %})
               AND bigmap_meta.action = 'clear'
@@ -148,8 +148,8 @@ FROM (
         WHERE NOT t.latest_deleted
           AND t2 IS NULL
     ) t  -- t with bigmap clears unfolded
-    JOIN tx_contexts ctx
+    JOIN "{{ main_schema }}".tx_contexts ctx
       ON ctx.id = t.tx_context_id
-    JOIN levels level_meta
+    JOIN "{{ main_schema }}".levels level_meta
       ON level_meta.level = ctx.level
 ) t;

--- a/sql/templates/update-snapshot-derived.sql
+++ b/sql/templates/update-snapshot-derived.sql
@@ -26,7 +26,7 @@ FROM (
         ctx.id,
         ctx.level
       FROM "{{ contract_schema }}"."{{ parent_table }}" t
-      JOIN tx_contexts ctx
+      JOIN "{{ main_schema }}".tx_contexts ctx
         ON ctx.id = t.tx_context_id
       ORDER BY
           ctx.level DESC,
@@ -36,7 +36,7 @@ FROM (
           COALESCE(ctx.internal_number, -1) DESC
       LIMIT 1
     ) last_ctx
-    JOIN levels level_meta
+    JOIN "{{ main_schema }}".levels level_meta
       ON level_meta.level = last_ctx.level
     WHERE t.tx_context_id = last_ctx.id
 ) t;
@@ -68,9 +68,9 @@ FROM (
         t.tx_context_id
         {% call unfold(columns, "t", true) %}
     FROM "{{ contract_schema }}"."{{ table }}" t
-    JOIN tx_contexts ctx
+    JOIN "{{ main_schema }}".tx_contexts ctx
       ON ctx.id = t.tx_context_id
-    JOIN levels level_meta
+    JOIN "{{ main_schema }}".levels level_meta
       ON level_meta.level = ctx.level
     WHERE t.tx_context_id IN ({% call unfold(tx_context_ids, "", false) %})
 ) t;

--- a/src/sql/db.rs
+++ b/src/sql/db.rs
@@ -32,6 +32,7 @@ pub(crate) enum IndexerMode {
 #[derive(Template)]
 #[template(path = "repopulate-snapshot-derived.sql", escape = "none")]
 struct RepopulateSnapshotDerivedTmpl<'a> {
+    main_schema: &'a str,
     contract_schema: &'a str,
     table: &'a str,
     parent_table: &'a str,
@@ -40,6 +41,7 @@ struct RepopulateSnapshotDerivedTmpl<'a> {
 #[derive(Template)]
 #[template(path = "repopulate-changes-derived.sql", escape = "none")]
 struct RepopulateChangesDerivedTmpl<'a> {
+    main_schema: &'a str,
     contract_schema: &'a str,
     table: &'a str,
     columns: &'a [String],
@@ -48,6 +50,7 @@ struct RepopulateChangesDerivedTmpl<'a> {
 #[derive(Template)]
 #[template(path = "update-snapshot-derived.sql", escape = "none")]
 struct UpdateSnapshotDerivedTmpl<'a> {
+    main_schema: &'a str,
     contract_schema: &'a str,
     table: &'a str,
     parent_table: &'a str,
@@ -57,6 +60,7 @@ struct UpdateSnapshotDerivedTmpl<'a> {
 #[derive(Template)]
 #[template(path = "update-changes-derived.sql", escape = "none")]
 struct UpdateChangesDerivedTmpl<'a> {
+    main_schema: &'a str,
     contract_schema: &'a str,
     table: &'a str,
     columns: &'a [String],
@@ -129,7 +133,8 @@ FROM indexer_state
                 .as_str(),
         )?;
         conn.simple_query(
-            PostgresqlGenerator::create_common_tables().as_str(),
+            PostgresqlGenerator::create_common_tables(&self.main_schema)
+                .as_str(),
         )?;
         Ok(())
     }
@@ -175,11 +180,7 @@ WHERE table_schema = $1
                     table_i = i,
                     table_total = tables.len(),
                 );
-                DBClient::repopulate_derived_table(
-                    &mut tx,
-                    &contract.cid,
-                    table,
-                )?;
+                self.repopulate_derived_table(&mut tx, &contract.cid, table)?;
             }
         }
         tx.commit()?;
@@ -187,6 +188,7 @@ WHERE table_schema = $1
     }
 
     fn repopulate_derived_table(
+        &self,
         tx: &mut Transaction,
         contract_id: &ContractID,
         table: &Table,
@@ -198,6 +200,7 @@ WHERE table_schema = $1
                 PostgresqlGenerator::table_parent_name(table)
                     .unwrap_or(table.name.clone());
             let tmpl = RepopulateSnapshotDerivedTmpl {
+                main_schema: &self.main_schema,
                 contract_schema: &contract_id.name,
                 table: &table.name,
                 parent_table: &parent_table,
@@ -206,6 +209,7 @@ WHERE table_schema = $1
             tx.simple_query(&tmpl.render()?)?;
         } else {
             let tmpl = RepopulateChangesDerivedTmpl {
+                main_schema: &self.main_schema,
                 contract_schema: &contract_id.name,
                 table: &table.name,
                 columns: &columns,
@@ -218,6 +222,7 @@ WHERE table_schema = $1
     }
 
     pub(crate) fn update_derived_tables(
+        &self,
         tx: &mut Transaction,
         contract: &relational::Contract,
         tx_contexts: &[TxContext],
@@ -239,7 +244,7 @@ WHERE table_schema = $1
                 .iter()
                 .any(|prefix| table.name.starts_with(prefix))
             {
-                DBClient::update_derived_table(
+                self.update_derived_table(
                     tx,
                     &contract.cid,
                     table,
@@ -251,6 +256,7 @@ WHERE table_schema = $1
     }
 
     fn update_derived_table(
+        &self,
         tx: &mut Transaction,
         contract_id: &ContractID,
         table: &Table,
@@ -268,6 +274,7 @@ WHERE table_schema = $1
                 PostgresqlGenerator::table_parent_name(table)
                     .unwrap_or(table.name.clone());
             let tmpl = UpdateSnapshotDerivedTmpl {
+                main_schema: &self.main_schema,
                 contract_schema: &contract_id.name,
                 table: &table.name,
                 parent_table: &parent_table,
@@ -277,6 +284,7 @@ WHERE table_schema = $1
             tx.simple_query(&tmpl.render()?)?;
         } else {
             let tmpl = UpdateChangesDerivedTmpl {
+                main_schema: &self.main_schema,
                 contract_schema: &contract_id.name,
                 table: &table.name,
                 columns: &columns,
@@ -351,7 +359,10 @@ CREATE SCHEMA IF NOT EXISTS "{contract_schema}";
                 contract_schema = contract.cid.name
             ));
 
-            let generator = PostgresqlGenerator::new(&contract.cid);
+            let generator = PostgresqlGenerator::new(
+                self.main_schema.clone(),
+                &contract.cid,
+            );
 
             for table in &tables {
                 let table_def = generator.create_table_definition(table)?;

--- a/src/sql/inserter.rs
+++ b/src/sql/inserter.rs
@@ -136,7 +136,7 @@ fn insert_batch(
 
     if update_derived_tables {
         for (contract_id, (contract, ctxs)) in &batch.contract_tx_contexts {
-            DBClient::update_derived_tables(
+            dbcli.update_derived_tables(
                 &mut db_tx,
                 &contract,
                 ctxs,

--- a/test/regression/1.query
+++ b/test/regression/1.query
@@ -1,4 +1,4 @@
-select count(1) from que_pasa.tx_contexts;
+select count(1) from "custom_Main_Schema".tx_contexts;
  count 
 -------
   1132

--- a/test/regression/2.query
+++ b/test/regression/2.query
@@ -1,4 +1,4 @@
-select count(1) from que_pasa.contracts;
+select count(1) from "custom_Main_Schema".contracts;
  count 
 -------
    147

--- a/test/regression/3.query
+++ b/test/regression/3.query
@@ -1,4 +1,4 @@
-select count(1) from que_pasa.contract_levels;
+select count(1) from "custom_Main_Schema".contract_levels;
  count 
 -------
    313

--- a/test/regression/4.query
+++ b/test/regression/4.query
@@ -1,4 +1,4 @@
-select count(1) from que_pasa.contract_deps;
+select count(1) from "custom_Main_Schema".contract_deps;
  count 
 -------
      1


### PR DESCRIPTION
The database stored procedures relied in some places implicitly and in others explicitly on --main-schema being the default (que_pasa). This PR fixes this, makes all FROM and JOIN statements rely explicitly on the --main-schema setting.